### PR TITLE
:sparkles: Add Assertion Refinement tools to MQT Debugger 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - assertion-tools
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ wheelhouse/
 
 # test code for the CLIFrontEnd
 app/code/*.qasm
+
+.python-version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_MQT_DEBUGGER_BINDINGS)
 
   # top-level call to find Python
   find_package(
-    Python 3.8 REQUIRED
+    Python 3.9 REQUIRED
     COMPONENTS Interpreter Development.Module
     OPTIONAL_COMPONENTS Development.SABIModule)
 endif()

--- a/include/backend/dd/DDSimDebug.hpp
+++ b/include/backend/dd/DDSimDebug.hpp
@@ -668,17 +668,6 @@ bool isSubStateVectorLegal(const Statevector& full,
                            std::vector<size_t>& targetQubits);
 
 /**
- * @brief Gets the partial state vector by tracing out individual qubits from
- * the full state vector.
- * @param sv The full state vector.
- * @param traceOut The indices of the qubits to trace out.
- * @return The partial state vector.
- */
-std::vector<std::vector<Complex>>
-getPartialTraceFromStateVector(const Statevector& sv,
-                               const std::vector<size_t>& traceOut);
-
-/**
  * @brief Gets the target variables of an instruction.
  *
  * If the instruction targets are indexed registers, they are taken directly.

--- a/include/backend/dd/DDSimDebug.hpp
+++ b/include/backend/dd/DDSimDebug.hpp
@@ -620,6 +620,14 @@ bool checkAssertion(DDSimulationState* ddsim,
 std::string getClassicalBitName(DDSimulationState* ddsim, size_t index);
 
 /**
+ * @brief Gets the name of a qubit variable by its index.
+ * @param ddsim The simulation state to query.
+ * @param index The index of the qubit variable.
+ * @return The name of the qubit variable.
+ */
+std::string getQuantumBitName(DDSimulationState* ddsim, size_t index);
+
+/**
  * @brief Gets the qubit index from a variable name.
  *
  * If the variable is in the global scope, the index is based on the index of

--- a/include/backend/dd/DDSimDebug.hpp
+++ b/include/backend/dd/DDSimDebug.hpp
@@ -491,6 +491,20 @@ Result ddsimGetClassicalVariableName(SimulationState* self,
                                      size_t variableIndex, char* output);
 
 /**
+ * @brief Gets the name of a quantum variable by its index.
+ *
+ * For registers, each index is counted as a separate variable and can be
+ * accessed separately. This method will return the name of the specific
+ * index of the register.
+ * @param self The instance to query.
+ * @param variableIndex The index of the variable.
+ * @param output A buffer to store the name of the variable.
+ * @return The result of the operation.
+ */
+Result ddsimGetQuantumVariableName(SimulationState* self, size_t variableIndex,
+                                   char* output);
+
+/**
  * @brief Gets the full state vector of the simulation at the current time.
  *
  * The state vector is expected to be initialized with the correct number of

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -8,6 +8,7 @@
 #include "backend/diagnostics.h"
 #include "common.h"
 #include "common/parsing/AssertionParsing.hpp"
+#include "common/parsing/CodePreprocessing.hpp"
 
 #include <cstddef>
 #include <map>
@@ -43,6 +44,8 @@ struct DDDiagnostics {
    * @brief The actual qubits that each instruction has targeted.
    */
   std::map<size_t, std::set<std::vector<size_t>>> actualQubits;
+
+  std::vector<std::pair<size_t, size_t>> assertionsToMove;
 };
 
 /**
@@ -162,6 +165,21 @@ size_t dddiagnosticsPotentialErrorCauses(Diagnostics* self, ErrorCause* output,
                                          size_t count);
 
 /**
+ * @brief Suggest movements of assertions to better positions.
+ * @param self The diagnostics instance to query.
+ * @param originalPositions An array of assertion positions to be filled.
+ * Contains the original positions of the assertions that should be moved.
+ * @param suggestedPositions An array of assertion positions to be filled.
+ * Contains the suggested positions of the assertions that should be moved.
+ * @param count The maximum number of assertions to suggest movements for.
+ * @return The number of suggested movements.
+ */
+size_t dddiagnosticsSuggestAssertionMovements(Diagnostics* self,
+                                              size_t* originalPositions,
+                                              size_t* suggestedPositions,
+                                              size_t count);
+
+/**
  * @brief Creates a new `DDDiagnostics` instance.
  *
  * This method expects an allocated memory block for the `DDDiagnostics`
@@ -185,6 +203,14 @@ Result destroyDDDiagnostics([[maybe_unused]] DDDiagnostics* self);
  * @param instruction The instruction that was executed.
  */
 void dddiagnosticsOnStepForward(DDDiagnostics* diagnostics, size_t instruction);
+
+/**
+ * @brief Called, whenever simulation steps forward to update the diagnostics.
+ * @param diagnostics The diagnostics instance to update.
+ * @param instruction The instruction that was executed.
+ */
+void dddiagnosticsOnCodePreprocessing(
+    DDDiagnostics* diagnostics, const std::vector<Instruction>& instructions);
 
 /**
  * @brief Tries to find potential errors caused by missing interactions at

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -46,6 +46,7 @@ struct DDDiagnostics {
   std::map<size_t, std::set<std::vector<size_t>>> actualQubits;
 
   std::vector<std::pair<size_t, size_t>> assertionsToMove;
+  std::map<size_t, std::set<std::set<std::string>>> assertionsEntToInsert;
 };
 
 /**
@@ -180,6 +181,25 @@ size_t dddiagnosticsSuggestAssertionMovements(Diagnostics* self,
                                               size_t count);
 
 /**
+ * @brief Suggest new assertions to be added to the code.
+ *
+ * These assertions are added by first observing assertions that failed during
+ * previous iterations. Therefore, the simulation must be run at least once
+ * before calling this function.
+ *
+ * @param self The diagnostics instance to query.
+ * @param suggestedPositions An array of assertion positions to be filled.
+ * @param suggestedAssertions An array of assertion instruction strings to be
+ * filled. Each string expects a size of up to 256 characters.
+ * @param count The maximum number of assertions to suggest.
+ * @return The number of suggested assertions.
+ */
+size_t dddiagnosticsSuggestNewAssertions(Diagnostics* self,
+                                         size_t* suggestedPositions,
+                                         char** suggestedAssertions,
+                                         size_t count);
+
+/**
  * @brief Creates a new `DDDiagnostics` instance.
  *
  * This method expects an allocated memory block for the `DDDiagnostics`
@@ -205,12 +225,20 @@ Result destroyDDDiagnostics([[maybe_unused]] DDDiagnostics* self);
 void dddiagnosticsOnStepForward(DDDiagnostics* diagnostics, size_t instruction);
 
 /**
- * @brief Called, whenever simulation steps forward to update the diagnostics.
+ * @brief Called during code preprocessing after parsing all instructions.
  * @param diagnostics The diagnostics instance to update.
- * @param instruction The instruction that was executed.
+ * @param instructions The parsed instructions.
  */
 void dddiagnosticsOnCodePreprocessing(
     DDDiagnostics* diagnostics, const std::vector<Instruction>& instructions);
+
+/**
+ * @brief Called, whenever an assertion fails to update the diagnostics.
+ * @param diagnostics The diagnostics instance to update.
+ * @param instruction The instruction that was executed.
+ */
+void dddiagnosticsOnFailedAssertion(DDDiagnostics* diagnostics,
+                                    size_t instruction);
 
 /**
  * @brief Tries to find potential errors caused by missing interactions at

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -79,7 +79,8 @@ struct DDDiagnostics {
   std::map<size_t, std::set<std::vector<size_t>>> actualQubits;
 
   std::vector<std::pair<size_t, size_t>> assertionsToMove;
-  std::map<size_t, std::set<std::set<std::string>>> assertionsEntToInsert;
+  std::map<size_t, std::set<std::pair<std::set<std::string>, size_t>>>
+      assertionsEntToInsert;
   std::map<size_t, std::vector<InsertEqualityAssertion>> assertionsEqToInsert;
 };
 

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -16,13 +16,37 @@
 #include <set>
 #include <vector>
 
+/**
+ * @brief Represents an equality assertion that should be inserted into the
+ * program.
+ */
 struct InsertEqualityAssertion {
+
+  /**
+   * @brief The index of the instruction where the assertion should be inserted.
+   */
   size_t instructionIndex;
+
+  /**
+   * @brief The amplitudes that the assertion should check for equality.
+   */
   std::vector<Complex> amplitudes;
+
+  /**
+   * @brief The similarity threshold for the assertion.
+   */
   double similarity;
+
+  /**
+   * @brief The target qubits of the assertion.
+   */
   std::vector<std::string> targets;
 
-  // Define operator== to support equality comparisons
+  /**
+   * @brief Check whether two InsertEqualityAssertion instances are equal.
+   * @param other The other InsertEqualityAssertion instance to compare with.
+   * @return True if the instances are equal, false otherwise.
+   */
   bool operator==(const InsertEqualityAssertion& other) const {
     if (instructionIndex != other.instructionIndex ||
         targets != other.targets) {
@@ -78,9 +102,22 @@ struct DDDiagnostics {
    */
   std::map<size_t, std::set<std::vector<size_t>>> actualQubits;
 
+  /**
+   * @brief Assertions that have been identified to be moved in the program.
+   */
   std::vector<std::pair<size_t, size_t>> assertionsToMove;
+
+  /**
+   * @brief The entanglement assertions that have been identified to be added to
+   * the program.
+   */
   std::map<size_t, std::set<std::pair<std::set<std::string>, size_t>>>
       assertionsEntToInsert;
+
+  /**
+   * @brief The equality assertions that have been identified to be added to the
+   * program.
+   */
   std::map<size_t, std::vector<InsertEqualityAssertion>> assertionsEqToInsert;
 };
 

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -16,6 +16,39 @@
 #include <set>
 #include <vector>
 
+struct InsertEqualityAssertion {
+  size_t instructionIndex;
+  std::vector<Complex> amplitudes;
+  double similarity;
+  std::vector<std::string> targets;
+
+  // Define operator== to support equality comparisons
+  bool operator==(const InsertEqualityAssertion& other) const {
+    if (instructionIndex != other.instructionIndex ||
+        targets != other.targets) {
+      return false;
+    }
+
+    if ((similarity - other.similarity) < -1e-10 ||
+        (similarity - other.similarity) > 1e-10) {
+      return false;
+    }
+
+    for (size_t i = 0; i < amplitudes.size(); i++) {
+      if ((amplitudes[i].real - other.amplitudes[i].real) < -1e-10 ||
+          (amplitudes[i].real - other.amplitudes[i].real) > 1e-10) {
+        return false;
+      }
+      if ((amplitudes[i].imaginary - other.amplitudes[i].imaginary) < -1e-10 ||
+          (amplitudes[i].imaginary - other.amplitudes[i].imaginary) > 1e-10) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+};
+
 struct DDSimulationState;
 
 /**
@@ -47,6 +80,7 @@ struct DDDiagnostics {
 
   std::vector<std::pair<size_t, size_t>> assertionsToMove;
   std::map<size_t, std::set<std::set<std::string>>> assertionsEntToInsert;
+  std::map<size_t, std::vector<InsertEqualityAssertion>> assertionsEqToInsert;
 };
 
 /**

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
 #include <vector>
 
 /**

--- a/include/backend/dd/DDSimDiagnostics.hpp
+++ b/include/backend/dd/DDSimDiagnostics.hpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/include/backend/debug.h
+++ b/include/backend/debug.h
@@ -292,6 +292,20 @@ struct SimulationStateStruct {
                                      size_t variableIndex, char* output);
 
   /**
+   * @brief Gets the name of a quantum variable by its index.
+   *
+   * For registers, each index is counted as a separate variable and can be
+   * accessed separately. This method will return the name of the specific
+   * index of the register.
+   * @param self The instance to query.
+   * @param variableIndex The index of the variable.
+   * @param output A buffer to store the name of the variable.
+   * @return The result of the operation.
+   */
+  Result (*getQuantumVariableName)(SimulationState* self, size_t variableIndex,
+                                   char* output);
+
+  /**
    * @brief Gets the full state vector of the simulation at the current time.
    *
    * The state vector is expected to be initialized with the correct number of

--- a/include/backend/diagnostics.h
+++ b/include/backend/diagnostics.h
@@ -176,7 +176,11 @@ struct DiagnosticsStruct {
                                  size_t count);
 
   /**
-   * @brief Suggest movements of assertions to better positions.
+   * @brief Suggest movements of assertions to better positions.\n\n
+   *
+   * Calling this function with a `count` of 0 will return the number of
+   * assertions that can be suggested.
+   *
    * @param self The diagnostics instance to query.
    * @param originalPositions An array of assertion positions to be filled.
    * Contains the original positions of the assertions that should be moved.
@@ -194,7 +198,10 @@ struct DiagnosticsStruct {
    *
    * These assertions are added by first observing assertions that failed during
    * previous iterations. Therefore, the simulation must be run at least once
-   * before calling this function.
+   * before calling this function.\n\n
+   *
+   * Calling this function with a `count` of 0 will return the number of
+   * assertions that can be suggested.
    *
    * @param self The diagnostics instance to query.
    * @param suggestedPositions An array of assertion positions to be filled.

--- a/include/backend/diagnostics.h
+++ b/include/backend/diagnostics.h
@@ -174,6 +174,20 @@ struct DiagnosticsStruct {
    */
   size_t (*potentialErrorCauses)(Diagnostics* self, ErrorCause* output,
                                  size_t count);
+
+  /**
+   * @brief Suggest movements of assertions to better positions.
+   * @param self The diagnostics instance to query.
+   * @param originalPositions An array of assertion positions to be filled.
+   * Contains the original positions of the assertions that should be moved.
+   * @param suggestedPositions An array of assertion positions to be filled.
+   * Contains the suggested positions of the assertions that should be moved.
+   * @param count The maximum number of assertions to suggest movements for.
+   * @return The number of suggested movements.
+   */
+  size_t (*suggestAssertionMovements)(Diagnostics* self,
+                                      size_t* originalPositions,
+                                      size_t* suggestedPositions, size_t count);
 };
 
 #ifdef __cplusplus

--- a/include/backend/diagnostics.h
+++ b/include/backend/diagnostics.h
@@ -188,6 +188,23 @@ struct DiagnosticsStruct {
   size_t (*suggestAssertionMovements)(Diagnostics* self,
                                       size_t* originalPositions,
                                       size_t* suggestedPositions, size_t count);
+
+  /**
+   * @brief Suggest new assertions to be added to the code.
+   *
+   * These assertions are added by first observing assertions that failed during
+   * previous iterations. Therefore, the simulation must be run at least once
+   * before calling this function.
+   *
+   * @param self The diagnostics instance to query.
+   * @param suggestedPositions An array of assertion positions to be filled.
+   * @param suggestedAssertions An array of assertion instruction strings to be
+   * filled. Each string expects a size of up to 256 characters.
+   * @param count The maximum number of assertions to suggest.
+   * @return The number of suggested assertions.
+   */
+  size_t (*suggestNewAssertions)(Diagnostics* self, size_t* suggestedPositions,
+                                 char** suggestedAssertions, size_t count);
 };
 
 #ifdef __cplusplus

--- a/include/common/ComplexMathematics.hpp
+++ b/include/common/ComplexMathematics.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file ComplexMathematics.hpp
+ * @brief Provides maths methods for complex numbers.
+ */
+
+#pragma once
+
+#include "common.h"
+
+#include <Eigen/Dense>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Compute the magnitude of a complex number.
+ * @param c The complex number.
+ * @return The computed magnitude.
+ */
+double complexMagnitude(Complex& c);
+
+/**
+ * @brief Add two complex numbers.
+ * @param c1 The first complex number.
+ * @param c2 The second complex number.
+ * @return The sum of the two complex numbers.
+ */
+Complex complexAddition(const Complex& c1, const Complex& c2);
+
+/**
+ * @brief Multiply two complex numbers.
+ * @param c1 The first complex number.
+ * @param c2 The second complex number.
+ * @return The product of the two complex numbers.
+ */
+Complex complexMultiplication(const Complex& c1, const Complex& c2);
+
+/**
+ * @brief Compute the complex conjugate of a complex number.
+ * @param c The complex number.
+ * @return The complex conjugate of the input complex number.
+ */
+Complex complexConjugate(const Complex& c);
+
+/**
+ * @brief Check if two qubits are entangled in a given density matrix.
+ *
+ * This is done by tracing out all other qubits from a density matrix and then
+ * checking whether the shared information is greater than 0.
+ * @param densityMatrix The density matrix to check for entanglement.
+ * @param qubit1 The first qubit to check.
+ * @param qubit2 The second qubit to check.
+ * @return True if the qubits are entangled, false otherwise.
+ */
+bool areQubitsEntangled(std::vector<std::vector<Complex>>& densityMatrix,
+                        size_t qubit1, size_t qubit2);
+
+/**
+ * @brief Translate a given statevector to a density matrix.
+ *
+ * @param sv The statevector to translate.
+ * @return The computed density matrix.
+ */
+std::vector<std::vector<Complex>> toDensityMatrix(const Statevector& sv);
+
+/**
+ * @brief Check if the partial trace of a given state vector is pure.
+ *
+ * This is true if and only if the trace of the square of the traced out density
+ * matrix is equal to 1.
+ * @param sv The state vector to check.
+ * @param traceOut The indices of the qubits to trace out.
+ * @return True if the partial trace is pure, false otherwise.
+ */
+bool partialTraceIsPure(const Statevector& sv,
+                        const std::vector<size_t>& traceOut);
+
+/**
+ * @brief Gets the partial state vector by tracing out individual qubits from
+ * the full state vector.
+ * @param sv The full state vector.
+ * @param traceOut The indices of the qubits to trace out.
+ * @return The partial state vector.
+ */
+std::vector<std::vector<Complex>>
+getPartialTraceFromStateVector(const Statevector& sv,
+                               const std::vector<size_t>& traceOut);
+
+/**
+ * @brief Convert a given vector-of-vectors matrix to an Eigen3 matrix.
+ * @param matrix The vector-of-vectors matrix to convert.
+ * @return A new Eigen3 matrix.
+ */
+Eigen::MatrixXcd // NOLINT
+toEigenMatrix(const std::vector<std::vector<Complex>>& matrix);
+
+/**
+ * @brief Compute the amplitudes of a given state vector's sub-state.
+ * @param sv The state vector to compute the sub-state from.
+ * @param qubits The indices of the qubits to include in the sub-state.
+ * @return The computed sub-state vector amplitudes.
+ */
+std::vector<Complex>
+getSubStateVectorAmplitudes(const Statevector& sv,
+                            const std::vector<size_t>& qubits);
+
+/**
+ * @brief Generate a string representation of a complex number.
+ * @param c The complex number.
+ * @return The string representation of the complex number.
+ */
+std::string complexToString(const Complex& c);

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -4,6 +4,7 @@
 #include "CodePreprocessing.hpp"
 
 #include <memory>
+#include <string>
 
 /**
  * @brief Define a general commutation rule.
@@ -54,7 +55,7 @@
  *
  * Can be either `Commutes`, `DoesNotCommute`, or `Unknown`.
  */
-enum class CommutationResult {
+enum class CommutationResult : uint8_t {
   /**
    * @brief Indicates that the instructions commute with certainty.
    */

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -5,16 +5,16 @@
 
 #include <memory>
 
-#define COMMUTATIVITY_RULE_GENERAL(name, expression)                           \
-  COMMUTATIVITY_RULE_TEMPLATE(Assertion, name, expression)
+#define COMMUTATION_RULE_GENERAL(name, expression)                             \
+  COMMUTATION_RULE_TEMPLATE(Assertion, name, expression)
 
-#define COMMUTATIVITY_RULE_ENT(name, expression)                               \
-  COMMUTATIVITY_RULE_TEMPLATE(EntanglementAssertion, name, expression)
+#define COMMUTATION_RULE_ENT(name, expression)                                 \
+  COMMUTATION_RULE_TEMPLATE(EntanglementAssertion, name, expression)
 
-#define COMMUTATIVITY_RULE_SUP(name, expression)                               \
-  COMMUTATIVITY_RULE_TEMPLATE(SuperpositionAssertion, name, expression)
+#define COMMUTATION_RULE_SUP(name, expression)                                 \
+  COMMUTATION_RULE_TEMPLATE(SuperpositionAssertion, name, expression)
 
-#define COMMUTATIVITY_RULE_TEMPLATE(type, name, expression)                    \
+#define COMMUTATION_RULE_TEMPLATE(type, name, expression)                      \
   const auto name = [](const type* assertion,                                  \
                        const std::string& instructionName,                     \
                        const std::vector<std::string>& arguments) {            \
@@ -24,7 +24,7 @@
     return expression;                                                         \
   }
 
-enum class CommutativityResult {
+enum class CommutationResult {
   Commutes,
   DoesNotCommute,
   Unknown,

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -5,8 +5,17 @@
 
 #include <memory>
 
+#define COMMUTATIVITY_RULE_GENERAL(name, expression)                           \
+  COMMUTATIVITY_RULE_TEMPLATE(Assertion, name, expression)
+
 #define COMMUTATIVITY_RULE_ENT(name, expression)                               \
-  const auto name = [](const EntanglementAssertion* assertion,                 \
+  COMMUTATIVITY_RULE_TEMPLATE(EntanglementAssertion, name, expression)
+
+#define COMMUTATIVITY_RULE_SUP(name, expression)                               \
+  COMMUTATIVITY_RULE_TEMPLATE(SuperpositionAssertion, name, expression)
+
+#define COMMUTATIVITY_RULE_TEMPLATE(type, name, expression)                    \
+  const auto name = [](const type* assertion,                                  \
                        const std::string& instructionName,                     \
                        const std::vector<std::string>& arguments) {            \
     (void)assertion;                                                           \
@@ -15,15 +24,11 @@
     return expression;                                                         \
   }
 
-#define COMMUTATIVITY_RULE_SUP(name, expression)                               \
-  const auto name = [](const SuperpositionAssertion* assertion,                \
-                       const std::string& instructionName,                     \
-                       const std::vector<std::string>& arguments) {            \
-    (void)assertion;                                                           \
-    (void)instructionName;                                                     \
-    (void)arguments;                                                           \
-    return expression;                                                         \
-  }
+enum class CommutativityResult {
+  Commutes,
+  DoesNotCommute,
+  Unknown,
+};
 
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const Instruction& instruction);

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 
 /**
  * @brief Define a general commutation rule.

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -5,15 +5,40 @@
 
 #include <memory>
 
+/**
+ * @brief Define a general commutation rule.
+ *
+ * @param name The name of the commutation rule.
+ * @param expression The expression that performs the check.
+ */
 #define COMMUTATION_RULE_GENERAL(name, expression)                             \
   COMMUTATION_RULE_TEMPLATE(Assertion, name, expression)
 
+/**
+ * @brief Define a commutation rule for entanglement assertions.
+ *
+ * @param name The name of the commutation rule.
+ * @param expression The expression that performs the check.
+ */
 #define COMMUTATION_RULE_ENT(name, expression)                                 \
   COMMUTATION_RULE_TEMPLATE(EntanglementAssertion, name, expression)
 
+/**
+ * @brief Define a commutation rule for superposition assertions.
+ *
+ * @param name The name of the commutation rule.
+ * @param expression The expression that performs the check.
+ */
 #define COMMUTATION_RULE_SUP(name, expression)                                 \
   COMMUTATION_RULE_TEMPLATE(SuperpositionAssertion, name, expression)
 
+/**
+ * @brief Define a template for commutation rules.
+ *
+ * @param type The type of assertion to check.
+ * @param name The name of the commutation rule.
+ * @param expression The expression that performs the check.
+ */
 #define COMMUTATION_RULE_TEMPLATE(type, name, expression)                      \
   const auto name = [](const type* assertion,                                  \
                        const std::string& instructionName,                     \
@@ -24,11 +49,32 @@
     return expression;                                                         \
   }
 
+/**
+ * @brief The possible results of a commutation check.
+ *
+ * Can be either `Commutes`, `DoesNotCommute`, or `Unknown`.
+ */
 enum class CommutationResult {
+  /**
+   * @brief Indicates that the instructions commute with certainty.
+   */
   Commutes,
+  /**
+   * @brief Indicates that the instructions do not commute with certainty.
+   */
   DoesNotCommute,
+  /**
+   * @brief Indicates that it cannot be said with certainty whether the
+   * instructions commute or not.
+   */
   Unknown,
 };
 
+/**
+ * @brief Check if an assertion commutes with an instruction.
+ * @param assertion The assertion to check.
+ * @param instruction The instruction to check.
+ * @return True if the assertion commutes with the instruction, false otherwise.
+ */
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const Instruction& instruction);

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "AssertionParsing.hpp"
+#include "CodePreprocessing.hpp"
+
+#include <memory>
+#include <string>
+
+bool doesCommute(const std::unique_ptr<Assertion>& assertion,
+                 const std::string& fullCode, const Instruction& instruction);

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -7,4 +7,4 @@
 #include <string>
 
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,
-                 const std::string& fullCode, const Instruction& instruction);
+                 const Instruction& instruction);

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -3,6 +3,7 @@
 #include "AssertionParsing.hpp"
 #include "CodePreprocessing.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/common/parsing/AssertionTools.hpp
+++ b/include/common/parsing/AssertionTools.hpp
@@ -4,7 +4,26 @@
 #include "CodePreprocessing.hpp"
 
 #include <memory>
-#include <string>
+
+#define COMMUTATIVITY_RULE_ENT(name, expression)                               \
+  const auto name = [](const EntanglementAssertion* assertion,                 \
+                       const std::string& instructionName,                     \
+                       const std::vector<std::string>& arguments) {            \
+    (void)assertion;                                                           \
+    (void)instructionName;                                                     \
+    (void)arguments;                                                           \
+    return expression;                                                         \
+  }
+
+#define COMMUTATIVITY_RULE_SUP(name, expression)                               \
+  const auto name = [](const SuperpositionAssertion* assertion,                \
+                       const std::string& instructionName,                     \
+                       const std::vector<std::string>& arguments) {            \
+    (void)assertion;                                                           \
+    (void)instructionName;                                                     \
+    (void)arguments;                                                           \
+    return expression;                                                         \
+  }
 
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const Instruction& instruction);

--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -309,3 +309,10 @@ bool isReset(const std::string& line);
  * @return True if the line is a barrier operation, false otherwise.
  */
 bool isBarrier(const std::string& line);
+
+/**
+ * @brief Parse the parameters or arguments from a given instruction.
+ * @param instruction The instruction to parse.
+ * @return A vector containing the parsed parameters.
+ */
+std::vector<std::string> parseParameters(const std::string& instruction)

--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -181,6 +182,24 @@ struct Instruction {
 };
 
 /**
+ * @brief Represents a classic-controlled gate in the code.
+ *
+ * Classic-controlled gates are defined using the `if` keyword with one of the
+ * following formats:\n `if (condition) operation;` or `if (condition) {
+ * operation1; operation2; ... }`
+ */
+struct ClassicControlledGate {
+  /**
+   * @brief The condition of the classic-controlled gate.
+   */
+  std::string condition;
+  /**
+   * @brief The quantum operations to perform if the condition is met.
+   */
+  std::vector<std::string> operations;
+};
+
+/**
  * @brief Represents a function definition in the code.
  */
 struct FunctionDefinition {
@@ -228,3 +247,65 @@ preprocessCode(const std::string& code, size_t startIndex,
                std::map<std::string, size_t>& definedRegisters,
                const std::vector<std::string>& shadowedRegisters,
                std::string& processedCode);
+
+/**
+ * @brief Check if a given line is a function definition.
+ *
+ * This is done by checking if it starts with `gate `.
+ * @param line The line to check.
+ * @return True if the line is a function definition, false otherwise.
+ */
+bool isFunctionDefinition(const std::string& line);
+
+/**
+ * @brief Check if a given line is a classic controlled gate.
+ *
+ * This is done by checking if it starts with `if` and contains parentheses.
+ * @param line The line to check.
+ * @return True if the line is a classic controlled gate, false otherwise.
+ */
+bool isClassicControlledGate(const std::string& line);
+
+/**
+ * @brief Parse a classic-controlled gate from a given line (or multiple lines)
+ * of code.
+ * @param code The code to parse.
+ * @return The parsed classic-controlled gate.
+ */
+ClassicControlledGate parseClassicControlledGate(const std::string& code);
+
+/**
+ * @brief Check if a given line is a variable declaration.
+ *
+ * This is done by checking if it contains `creg ` or `qreg `.
+ * @param line The line to check.
+ * @return True if the line is a variable declaration, false otherwise.
+ */
+bool isVariableDeclaration(const std::string& line);
+
+/**
+ * @brief Check if a given line is a measurement.
+ *
+ * This is done by checking if it contains the symbols `->`.
+ * @param line The line to check.
+ * @return True if the line is a measurement, false otherwise.
+ */
+bool isMeasurement(const std::string& line);
+
+/**
+ * @brief Check if a given line is a reset operation.
+ *
+ * This is done by checking if it starts with `reset `.
+ * @param line The line to check.
+ * @return True if the line is a reset operation, false otherwise.
+ */
+bool isReset(const std::string& line);
+
+/**
+ * @brief Check if a given line is a barrier operation.
+ *
+ * This is done by checking if it starts with `barrier ` or `barrier;`.
+ * @param line The line to check.
+ * @return True if the line is a barrier operation, false otherwise.
+ */
+bool isBarrier(const std::string& line);

--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -315,4 +315,4 @@ bool isBarrier(const std::string& line);
  * @param instruction The instruction to parse.
  * @return A vector containing the parsed parameters.
  */
-std::vector<std::string> parseParameters(const std::string& instruction)
+std::vector<std::string> parseParameters(const std::string& instruction);

--- a/include/common/parsing/Utils.hpp
+++ b/include/common/parsing/Utils.hpp
@@ -27,9 +27,11 @@ bool startsWith(const std::string& str, const std::string& prefix);
  * @brief Splits a string into a vector of strings based on a delimiter.
  * @param text The text to split.
  * @param delimiter The delimiter to split on.
+ * @param includeEmpty Whether to include empty strings in the result.
  * @return The vector of strings.
  */
-std::vector<std::string> splitString(const std::string& text, char delimiter);
+std::vector<std::string> splitString(const std::string& text, char delimiter,
+                                     bool includeEmpty = true);
 
 /**
  * @brief Splits a string into a vector of strings based on multiple delimiters.
@@ -38,10 +40,12 @@ std::vector<std::string> splitString(const std::string& text, char delimiter);
  *
  * @param text The text to split.
  * @param delimiters The delimiters to split on.
+ * @param includeEmpty Whether to include empty strings in the result.
  * @return The vector of strings.
  */
 std::vector<std::string> splitString(const std::string& text,
-                                     const std::vector<char>& delimiters);
+                                     const std::vector<char>& delimiters,
+                                     bool includeEmpty = true);
 
 /**
  * @brief Replaces all occurrences of a substring in a string with another
@@ -77,3 +81,11 @@ std::string removeWhitespace(std::string str);
  * @return True if the strings refer to the same variable, false otherwise.
  */
 bool variablesEqual(const std::string& v1, const std::string& v2);
+
+/**
+ * @brief Extracts the base name of a register.
+ *
+ * @param variable The variable to extract the base name from.
+ * @return The base name of the register.
+ */
+std::string variableBaseName(const std::string& variable);

--- a/include/frontend/cli/CliFrontEnd.hpp
+++ b/include/frontend/cli/CliFrontEnd.hpp
@@ -41,7 +41,11 @@ private:
   std::string currentCode;
 
   /**
-   * @brief Print the current state (state vector etc.) in the command line.
+   * @brief Print the current state of the simulation.
+   * @param state The simulation state.
+   * @param inspecting The instruction that is currently inspected (or -1ULL if
+   * nothing is being inspected).
+   * @param codeOnly If true, only the code is displayed, not the state.
    */
   void printState(SimulationState* state, size_t inspecting,
                   bool codeOnly = false);
@@ -50,4 +54,6 @@ private:
    * @brief Initialize the code for running it at a later time.
    */
   void initCode(const char* code);
+
+  void suggestUpdatedAssertions(SimulationState* state);
 };

--- a/include/frontend/cli/CliFrontEnd.hpp
+++ b/include/frontend/cli/CliFrontEnd.hpp
@@ -55,5 +55,10 @@ private:
    */
   void initCode(const char* code);
 
+  /**
+   * @brief Output a new code with updated assertions based on the assertion
+   * refinement rules.
+   * @param state The simulation state.
+   */
   void suggestUpdatedAssertions(SimulationState* state);
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   backend/dd/DDSimDebug.cpp
   backend/dd/DDSimDiagnostics.cpp
   common/parsing/AssertionParsing.cpp
+  common/parsing/AssertionTools.cpp
   common/parsing/CodePreprocessing.cpp
   common/parsing/ParsingError.cpp
   common/parsing/Utils.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(
   ${PROJECT_NAME}
   backend/dd/DDSimDebug.cpp
   backend/dd/DDSimDiagnostics.cpp
+  common/ComplexMathematics.cpp
+  common/ComplexMathematics.cpp
   common/parsing/AssertionParsing.cpp
   common/parsing/AssertionTools.cpp
   common/parsing/CodePreprocessing.cpp

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -1517,6 +1517,7 @@ std::string preprocessAssertionCode(const char* code,
                                     DDSimulationState* ddsim) {
 
   auto instructions = preprocessCode(code, ddsim->processedCode);
+  dddiagnosticsOnCodePreprocessing(&ddsim->diagnostics, instructions);
   std::vector<std::string> correctLines;
   ddsim->instructionTypes.clear();
   ddsim->functionDefinitions.clear();

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -328,6 +328,7 @@ Result ddsimStepForward(SimulationState* self) {
       const auto failed = !checkAssertion(ddsim, assertion);
       if (failed && ddsim->lastFailedAssertion != currentInstruction) {
         ddsim->lastFailedAssertion = currentInstruction;
+        dddiagnosticsOnFailedAssertion(&ddsim->diagnostics, currentInstruction);
         self->stepBackward(self);
       }
       return OK;
@@ -1660,6 +1661,15 @@ std::string preprocessAssertionCode(const char* code,
 
 std::string getClassicalBitName(DDSimulationState* ddsim, size_t index) {
   for (auto& reg : ddsim->classicalRegisters) {
+    if (index >= reg.index && index < reg.index + reg.size) {
+      return reg.name + "[" + std::to_string(index - reg.index) + "]";
+    }
+  }
+  return "UNKNOWN";
+}
+
+std::string getQuantumBitName(DDSimulationState* ddsim, size_t index) {
+  for (auto& reg : ddsim->qubitRegisters) {
     if (index >= reg.index && index < reg.index + reg.size) {
       return reg.name + "[" + std::to_string(index - reg.index) + "]";
     }

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -11,6 +11,7 @@
 #include "backend/diagnostics.h"
 #include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "common.h"
+#include "common/ComplexMathematics.hpp"
 #include "common/Span.hpp"
 #include "common/parsing/AssertionParsing.hpp"
 #include "common/parsing/CodePreprocessing.hpp"
@@ -721,24 +722,6 @@ Result ddsimGetStateVectorFull(SimulationState* self, Statevector* output) {
   return OK;
 }
 
-/**
- * @brief Convert a given vector-of-vectors matrix to an Eigen3 matrix.
- * @param matrix The vector-of-vectors matrix to convert.
- * @return A new Eigen3 matrix.
- */
-Eigen::MatrixXcd // NOLINT
-toEigenMatrix(const std::vector<std::vector<Complex>>& matrix) {
-  Eigen::MatrixXcd mat(static_cast<int64_t>(matrix.size()),  // NOLINT
-                       static_cast<int64_t>(matrix.size())); // NOLINT
-  for (size_t i = 0; i < matrix.size(); i++) {
-    for (size_t j = 0; j < matrix.size(); j++) {
-      mat(static_cast<int64_t>(i), static_cast<int64_t>(j)) = {
-          matrix[i][j].real, matrix[i][j].imaginary};
-    }
-  }
-  return mat;
-}
-
 Result ddsimGetStateVectorSub(SimulationState* self, size_t subStateSize,
                               const size_t* qubits, Statevector* output) {
   auto* ddsim = toDDSimulationState(self);
@@ -1008,46 +991,6 @@ std::pair<size_t, size_t> variableToQubitAt(DDSimulationState* ddsim,
 }
 
 /**
- * @brief Compute the magnitude of a complex number.
- * @param c The complex number.
- * @return The computed magnitude.
- */
-double complexMagnitude(Complex& c) {
-  return std::sqrt(c.real * c.real + c.imaginary * c.imaginary);
-}
-
-/**
- * @brief Multiply two complex numbers.
- * @param c1 The first complex number.
- * @param c2 The second complex number.
- * @return The product of the two complex numbers.
- */
-Complex complexMultiplication(const Complex& c1, const Complex& c2) {
-  const double real = c1.real * c2.real - c1.imaginary * c2.imaginary;
-  const double imaginary = c1.real * c2.imaginary + c1.imaginary * c2.real;
-  return {real, imaginary};
-}
-
-/**
- * @brief Compute the complex conjugate of a complex number.
- * @param c The complex number.
- * @return The complex conjugate of the input complex number.
- */
-Complex complexConjugate(const Complex& c) { return {c.real, -c.imaginary}; }
-
-/**
- * @brief Add two complex numbers.
- * @param c1 The first complex number.
- * @param c2 The second complex number.
- * @return The sum of the two complex numbers.
- */
-Complex complexAddition(const Complex& c1, const Complex& c2) {
-  const double real = c1.real + c2.real;
-  const double imaginary = c1.imaginary + c2.imaginary;
-  return {real, imaginary};
-}
-
-/**
  * @brief Compute the dot product of two state vectors.
  * @param sv1 The first state vector.
  * @param sv2 The second state vector.
@@ -1084,193 +1027,6 @@ std::vector<bool> extractBits(const std::vector<size_t>& indices,
     result[i] = (((value >> indices[i]) & 1) == 1);
   }
   return result;
-}
-
-/**
- * @brief Split a given number into two numbers partitioned by the bits at the
- * given indices.
- *
- * Starts by extracting the bits at the given indices of its binary
- * representation. Then, the extracted and non-extracted parts are converted
- * into two new numbers.
- * @param number The number to split.
- * @param n The number of bits in the binary representation.
- * @param bits The indices of the bits to extract.
- * @return The two new numbers, partitioned by the extracted bits.
- */
-std::pair<size_t, size_t> splitBitString(size_t number, size_t n,
-                                         const std::vector<size_t>& bits) {
-  size_t lenFirst = 0;
-  size_t lenSecond = 0;
-
-  size_t first = 0;
-  size_t second = 0;
-
-  for (size_t index = 0; index < n; index++) {
-    if (std::find(bits.begin(), bits.end(), index) != bits.end()) {
-      first |= (number & 1) << lenFirst;
-      lenFirst++;
-    } else {
-      second |= (number & 1) << lenSecond;
-      lenSecond++;
-    }
-    number >>= 1;
-  }
-  return {first, second};
-}
-
-/**
- * @brief Compute the partial trace of a given matrix.
- * @param matrix The matrix to compute the partial trace of.
- * @param indicesToTraceOut The indices of the qubits to trace out.
- * @param nQubits The total number of qubits.
- * @return The computed partial trace.
- */
-std::vector<std::vector<Complex>>
-getPartialTrace(const std::vector<std::vector<Complex>>& matrix,
-                const std::vector<size_t>& indicesToTraceOut, size_t nQubits) {
-  const auto traceSize = 1ULL << (nQubits - indicesToTraceOut.size());
-  std::vector<std::vector<Complex>> traceMatrix(
-      traceSize, std::vector<Complex>(traceSize, {0, 0}));
-  for (size_t i = 0; i < matrix.size(); i++) {
-    for (size_t j = 0; j < matrix.size(); j++) {
-      const auto split1 = splitBitString(i, nQubits, indicesToTraceOut);
-      const auto split2 = splitBitString(j, nQubits, indicesToTraceOut);
-      if (split1.first != split2.first) {
-        continue;
-      }
-      traceMatrix[split1.second][split2.second] = complexAddition(
-          traceMatrix[split1.second][split2.second], matrix[i][j]);
-    }
-  }
-  return traceMatrix;
-}
-
-/**
- * @brief Compute the entropy of a given matrix.
- * @param matrix The matrix to compute the entropy of.
- * @return The computed entropy.
- */
-double getEntropy(const std::vector<std::vector<Complex>>& matrix) {
-  const auto mat = toEigenMatrix(matrix);
-
-  const Eigen::ComplexEigenSolver<Eigen::MatrixXcd> solver(mat);
-  const auto& eigenvalues = solver.eigenvalues();
-  double entropy = 0;
-  for (const auto val : eigenvalues) {
-    const auto value =
-        (val.real() > -0.00001 && val.real() < 0) ? 0 : val.real();
-    if (value < 0) {
-      throw std::runtime_error("Negative eigenvalue");
-    }
-    if (value != 0) {
-      entropy -= val.real() * log2(val.real());
-    }
-  }
-  return entropy;
-}
-
-/**
- * @brief Compute the shared information of a given 4x4 density matrix.
- *
- * The density matrix is assumed to represent a two-qubit system.\n
- * The shared information is computed by adding up the entropy values of the two
- * new matrices created by tracing out each of the qubits and subtracting the
- * entropy of the original matrix.
- * @param matrix The density matrix to compute the shared information of.
- * @return The computed shared information.
- */
-double getSharedInformation(const std::vector<std::vector<Complex>>& matrix) {
-  const auto p0 = getPartialTrace(matrix, {1}, 2);
-  const auto p1 = getPartialTrace(matrix, {0}, 2);
-  return getEntropy(p0) + getEntropy(p1) - getEntropy(matrix);
-}
-
-/**
- * @brief Check if two qubits are entangled in a given density matrix.
- *
- * This is done by tracing out all other qubits from a density matrix and then
- * checking whether the shared information is greater than 0.
- * @param densityMatrix The density matrix to check for entanglement.
- * @param qubit1 The first qubit to check.
- * @param qubit2 The second qubit to check.
- * @return True if the qubits are entangled, false otherwise.
- */
-bool areQubitsEntangled(std::vector<std::vector<Complex>>& densityMatrix,
-                        size_t qubit1, size_t qubit2) {
-  const auto numQubits = static_cast<size_t>(std::log2(densityMatrix.size()));
-  if (numQubits == 2) {
-    return getSharedInformation(densityMatrix) > 0;
-  }
-  std::vector<size_t> toTraceOut;
-  for (size_t i = 0; i < numQubits; i++) {
-    if (i != qubit1 && i != qubit2) {
-      toTraceOut.push_back(i);
-    }
-  }
-  const auto partialTrace =
-      getPartialTrace(densityMatrix, toTraceOut, numQubits);
-  return getSharedInformation(partialTrace) > 0;
-}
-
-std::vector<std::vector<Complex>>
-getPartialTraceFromStateVector(const Statevector& sv,
-                               const std::vector<size_t>& traceOut) {
-  const auto traceSize = 1ULL << (sv.numQubits - traceOut.size());
-  const Span<Complex> amplitudes(sv.amplitudes, sv.numStates);
-  std::vector<std::vector<Complex>> traceMatrix(
-      traceSize, std::vector<Complex>(traceSize, {0, 0}));
-  for (size_t i = 0; i < sv.numStates; i++) {
-    for (size_t j = 0; j < sv.numStates; j++) {
-      const auto split1 = splitBitString(i, sv.numQubits, traceOut);
-      const auto split2 = splitBitString(j, sv.numQubits, traceOut);
-      if (split1.first != split2.first) {
-        continue;
-      }
-      const auto product = complexMultiplication(amplitudes[i], amplitudes[j]);
-      const auto row = split1.second;
-      const auto col = split2.second;
-      traceMatrix[row][col] = complexAddition(traceMatrix[row][col], product);
-    }
-  }
-  return traceMatrix;
-}
-
-/**
- * @brief Compute the trace of the square of a given matrix.
- *
- * This is done so that we don't have to compute the entire square of the
- * matrix.
- * @param matrix The matrix to compute the trace of the square of.
- * @return The computed trace of the square.
- */
-Complex getTraceOfSquare(const std::vector<std::vector<Complex>>& matrix) {
-  Complex runningSum{0, 0};
-  for (size_t i = 0; i < matrix.size(); i++) {
-    for (size_t k = 0; k < matrix.size(); k++) {
-      runningSum = complexAddition(
-          runningSum, complexMultiplication(matrix[i][k], matrix[k][i]));
-    }
-  }
-  return runningSum;
-}
-
-/**
- * @brief Check if the partial trace of a given state vector is pure.
- *
- * This is true if and only if the trace of the square of the traced out density
- * matrix is equal to 1.
- * @param sv The state vector to check.
- * @param traceOut The indices of the qubits to trace out.
- * @return True if the partial trace is pure, false otherwise.
- */
-bool partialTraceIsPure(const Statevector& sv,
-                        const std::vector<size_t>& traceOut) {
-  const auto traceMatrix = getPartialTraceFromStateVector(sv, traceOut);
-  const auto trace = getTraceOfSquare(traceMatrix);
-  const double epsilon = 0.00000001;
-  return trace.imaginary < epsilon && trace.imaginary > -epsilon &&
-         (trace.real - 1) < epsilon && (trace.real - 1) > -epsilon;
 }
 
 bool isSubStateVectorLegal(const Statevector& full,

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -745,42 +745,10 @@ Result ddsimGetStateVectorSub(SimulationState* self, size_t subStateSize,
     return ERROR;
   }
 
-  std::vector<size_t> otherQubits;
-  for (size_t i = 0; i < fullState.numQubits; i++) {
-    if (std::find(targetQubits.begin(), targetQubits.end(), i) ==
-        targetQubits.end()) {
-      otherQubits.push_back(i);
-    }
-  }
+  const auto subState = getSubStateVectorAmplitudes(fullState, targetQubits);
 
-  const auto traced = getPartialTraceFromStateVector(fullState, otherQubits);
-
-  // Create Eigen3 Matrix
-  const auto mat = toEigenMatrix(traced);
-
-  const Eigen::ComplexEigenSolver<Eigen::MatrixXcd> solver(mat); // NOLINT
-
-  const auto& vectors = solver.eigenvectors();
-  const auto& values = solver.eigenvalues();
-  const auto epsilon = 0.000001;
-  int index = -1;
-  for (int i = 0; i < values.size(); i++) {
-    if (values[i].imag() < -epsilon || values[i].imag() > epsilon) {
-      continue;
-    }
-    if (values[i].real() - 1 < -epsilon || values[i].real() - 1 > epsilon) {
-      continue;
-    }
-    index = i;
-  }
-
-  if (index == -1) {
-    return ERROR;
-  }
-
-  for (size_t i = 0; i < traced.size(); i++) {
-    outAmplitudes[i] = {vectors(static_cast<int>(i), index).real(),
-                        vectors(static_cast<int>(i), index).imag()};
+  for (size_t i = 0; i < subState.size(); i++) {
+    outAmplitudes[i] = subState[i];
   }
 
   return OK;

--- a/src/backend/dd/DDSimDiagnostics.cpp
+++ b/src/backend/dd/DDSimDiagnostics.cpp
@@ -15,6 +15,7 @@
 #include "common/parsing/CodePreprocessing.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -24,6 +25,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -606,6 +608,18 @@ size_t dddiagnosticsSuggestAssertionMovements(Diagnostics* self,
   return max;
 }
 
+/**
+ * @brief Finds a unique path between two qubits in the given graph, if it
+ * exists.
+ *
+ * If no such path exists, returns an empty vector.
+ *
+ * @param graph The graph to search in as a set of triples (start, end,
+ * instruction).
+ * @param start The starting vertex.
+ * @param end The ending vertex.
+ * @return The unique path between the two vertices, if it exists.
+ */
 std::vector<std::tuple<size_t, size_t, size_t>>
 findUniquePath(const std::set<std::tuple<size_t, size_t, size_t>>& graph,
                size_t start, size_t end) {
@@ -885,7 +899,6 @@ size_t dddiagnosticsSuggestNewAssertions(Diagnostics* self,
       const auto string =
           assertionString.str().substr(0, assertionString.str().size() - 2) +
           ";\n";
-      std::cout << string;
       strncpy(assertions[index], string.c_str(), string.length());
       index++;
       if (index == count) {

--- a/src/backend/dd/DDSimDiagnostics.cpp
+++ b/src/backend/dd/DDSimDiagnostics.cpp
@@ -590,6 +590,9 @@ size_t dddiagnosticsSuggestAssertionMovements(Diagnostics* self,
                                               size_t* suggestedPositions,
                                               size_t count) {
   DDDiagnostics* diagnostics = toDDDiagnostics(self);
+  if (count == 0) {
+    return diagnostics->assertionsToMove.size();
+  }
   const size_t max = count < diagnostics->assertionsToMove.size()
                          ? count
                          : diagnostics->assertionsToMove.size();
@@ -769,11 +772,22 @@ size_t dddiagnosticsSuggestNewAssertions(Diagnostics* self,
                                          size_t* suggestedPositions,
                                          char** suggestedAssertions,
                                          size_t count) {
+  auto* ddd = toDDDiagnostics(self);
+  if (count == 0) {
+    size_t totalNumber = 0;
+    for (const auto& entry : ddd->assertionsEntToInsert) {
+      totalNumber += entry.second.size();
+    }
+    for (const auto& entry : ddd->assertionsEqToInsert) {
+      totalNumber += entry.second.size();
+    }
+    return totalNumber;
+  }
+
   size_t index = 0;
   const Span<size_t> positions(suggestedPositions, count);
   const Span<char*> assertions(suggestedAssertions, count);
 
-  auto* ddd = toDDDiagnostics(self);
   for (const auto& entry : ddd->assertionsEntToInsert) {
     for (const auto& assertion : entry.second) {
       positions[index] = entry.first;
@@ -819,7 +833,6 @@ size_t dddiagnosticsSuggestNewAssertions(Diagnostics* self,
                     });
       finalStringStream << " }\n";
       const auto finalString = finalStringStream.str();
-      std::cout << finalString;
 
       strncpy(assertions[index], finalString.c_str(), finalString.length());
       index++;

--- a/src/backend/dd/DDSimDiagnostics.cpp
+++ b/src/backend/dd/DDSimDiagnostics.cpp
@@ -678,6 +678,12 @@ findUniquePath(const std::set<std::tuple<size_t, size_t, size_t>>& graph,
   return path;
 }
 
+/**
+ * @brief Suggest new assertions based on a failed entanglement assertion.
+ * @param self The diagnostics instance.
+ * @param instructionIndex The index of the assertion that failed.
+ * @param assertion The assertion that failed.
+ */
 void suggestBasedOnFailedEntanglementAssertion(
     DDDiagnostics* self, size_t instructionIndex,
     const EntanglementAssertion* assertion) {
@@ -753,6 +759,13 @@ void suggestBasedOnFailedEntanglementAssertion(
   }
 }
 
+/**
+ * @brief Suggest new assertions based on the splitting of an equality
+ * assertion.
+ * @param self The diagnostics instance.
+ * @param instructionIndex The index of the assertion to split.
+ * @param assertion The assertion to split.
+ */
 void suggestSplitEqualityAssertion(
     DDDiagnostics* self, size_t instructionIndex,
     const StatevectorEqualityAssertion* assertion) {

--- a/src/backend/dd/DDSimDiagnostics.cpp
+++ b/src/backend/dd/DDSimDiagnostics.cpp
@@ -11,15 +11,19 @@
 #include "common/Span.hpp"
 #include "common/parsing/AssertionParsing.hpp"
 #include "common/parsing/AssertionTools.hpp"
+#include "common/parsing/CodePreprocessing.hpp"
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -689,8 +693,9 @@ size_t dddiagnosticsSuggestNewAssertions(Diagnostics* self,
         assertionString << qubit + ", ";
       }
       const auto string =
-          assertionString.str().substr(0, assertionString.str().size() - 2);
-      strcpy(assertions[index], string.c_str());
+          assertionString.str().substr(0, assertionString.str().size() - 2) +
+          ";\n";
+      strncpy(assertions[index], string.c_str(), string.length());
       index++;
       if (index == count) {
         return index;

--- a/src/common/ComplexMathematics.cpp
+++ b/src/common/ComplexMathematics.cpp
@@ -1,0 +1,299 @@
+/**
+ * @file ComplexMathematics.cpp
+ * @brief Implementation of maths methods for complex numbers.
+ */
+
+#include "common/ComplexMathematics.hpp"
+
+#include "Eigen/src/Eigenvalues/ComplexEigenSolver.h"
+#include "common/Span.hpp"
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+/**
+ * @brief Compute the trace of the square of a given matrix.
+ *
+ * This is done so that we don't have to compute the entire square of the
+ * matrix.
+ * @param matrix The matrix to compute the trace of the square of.
+ * @return The computed trace of the square.
+ */
+Complex getTraceOfSquare(const std::vector<std::vector<Complex>>& matrix) {
+  Complex runningSum{0, 0};
+  for (size_t i = 0; i < matrix.size(); i++) {
+    for (size_t k = 0; k < matrix.size(); k++) {
+      runningSum = complexAddition(
+          runningSum, complexMultiplication(matrix[i][k], matrix[k][i]));
+    }
+  }
+  return runningSum;
+}
+
+/**
+ * @brief Split a given number into two numbers partitioned by the bits at the
+ * given indices.
+ *
+ * Starts by extracting the bits at the given indices of its binary
+ * representation. Then, the extracted and non-extracted parts are converted
+ * into two new numbers.
+ * @param number The number to split.
+ * @param n The number of bits in the binary representation.
+ * @param bits The indices of the bits to extract.
+ * @return The two new numbers, partitioned by the extracted bits.
+ */
+std::pair<size_t, size_t> splitBitString(size_t number, size_t n,
+                                         const std::vector<size_t>& bits) {
+  size_t lenFirst = 0;
+  size_t lenSecond = 0;
+
+  size_t first = 0;
+  size_t second = 0;
+
+  for (size_t index = 0; index < n; index++) {
+    if (std::find(bits.begin(), bits.end(), index) != bits.end()) {
+      first |= (number & 1) << lenFirst;
+      lenFirst++;
+    } else {
+      second |= (number & 1) << lenSecond;
+      lenSecond++;
+    }
+    number >>= 1;
+  }
+  return {first, second};
+}
+
+/**
+ * @brief Compute the partial trace of a given matrix.
+ * @param matrix The matrix to compute the partial trace of.
+ * @param indicesToTraceOut The indices of the qubits to trace out.
+ * @param nQubits The total number of qubits.
+ * @return The computed partial trace.
+ */
+std::vector<std::vector<Complex>>
+getPartialTrace(const std::vector<std::vector<Complex>>& matrix,
+                const std::vector<size_t>& indicesToTraceOut, size_t nQubits) {
+  const auto traceSize = 1ULL << (nQubits - indicesToTraceOut.size());
+  std::vector<std::vector<Complex>> traceMatrix(
+      traceSize, std::vector<Complex>(traceSize, {0, 0}));
+  for (size_t i = 0; i < matrix.size(); i++) {
+    for (size_t j = 0; j < matrix.size(); j++) {
+      const auto split1 = splitBitString(i, nQubits, indicesToTraceOut);
+      const auto split2 = splitBitString(j, nQubits, indicesToTraceOut);
+      if (split1.first != split2.first) {
+        continue;
+      }
+      traceMatrix[split1.second][split2.second] = complexAddition(
+          traceMatrix[split1.second][split2.second], matrix[i][j]);
+    }
+  }
+  return traceMatrix;
+}
+
+/**
+ * @brief Compute the entropy of a given matrix.
+ * @param matrix The matrix to compute the entropy of.
+ * @return The computed entropy.
+ */
+double getEntropy(const std::vector<std::vector<Complex>>& matrix) {
+  const auto mat = toEigenMatrix(matrix);
+
+  const Eigen::ComplexEigenSolver<Eigen::MatrixXcd> solver(mat);
+  const auto& eigenvalues = solver.eigenvalues();
+  double entropy = 0;
+  for (const auto val : eigenvalues) {
+    const auto value =
+        (val.real() > -0.00001 && val.real() < 0) ? 0 : val.real();
+    if (value < 0) {
+      throw std::runtime_error("Negative eigenvalue");
+    }
+    if (value != 0) {
+      entropy -= val.real() * log2(val.real());
+    }
+  }
+  return entropy;
+}
+
+/**
+ * @brief Compute the shared information of a given 4x4 density matrix.
+ *
+ * The density matrix is assumed to represent a two-qubit system.\n
+ * The shared information is computed by adding up the entropy values of the two
+ * new matrices created by tracing out each of the qubits and subtracting the
+ * entropy of the original matrix.
+ * @param matrix The density matrix to compute the shared information of.
+ * @return The computed shared information.
+ */
+double getSharedInformation(const std::vector<std::vector<Complex>>& matrix) {
+  const auto p0 = getPartialTrace(matrix, {1}, 2);
+  const auto p1 = getPartialTrace(matrix, {0}, 2);
+  return getEntropy(p0) + getEntropy(p1) - getEntropy(matrix);
+}
+
+Complex complexAddition(const Complex& c1, const Complex& c2) {
+  const double real = c1.real + c2.real;
+  const double imaginary = c1.imaginary + c2.imaginary;
+  return {real, imaginary};
+}
+
+Complex complexMultiplication(const Complex& c1, const Complex& c2) {
+  const double real = c1.real * c2.real - c1.imaginary * c2.imaginary;
+  const double imaginary = c1.real * c2.imaginary + c1.imaginary * c2.real;
+  return {real, imaginary};
+}
+
+Complex complexConjugate(const Complex& c) { return {c.real, -c.imaginary}; }
+
+bool areQubitsEntangled(std::vector<std::vector<Complex>>& densityMatrix,
+                        size_t qubit1, size_t qubit2) {
+  const auto numQubits = static_cast<size_t>(std::log2(densityMatrix.size()));
+  if (numQubits == 2) {
+    return getSharedInformation(densityMatrix) > 0;
+  }
+  std::vector<size_t> toTraceOut;
+  for (size_t i = 0; i < numQubits; i++) {
+    if (i != qubit1 && i != qubit2) {
+      toTraceOut.push_back(i);
+    }
+  }
+  const auto partialTrace =
+      getPartialTrace(densityMatrix, toTraceOut, numQubits);
+  return getSharedInformation(partialTrace) > 0;
+}
+
+std::vector<std::vector<Complex>> toDensityMatrix(const Statevector& sv) {
+  const Span<Complex> amplitudes(sv.amplitudes, sv.numStates);
+  std::vector<std::vector<Complex>> densityMatrix(
+      sv.numStates, std::vector<Complex>(sv.numStates, {0, 0}));
+  for (size_t i = 0; i < sv.numStates; i++) {
+    for (size_t j = 0; j < sv.numStates; j++) {
+      densityMatrix[i][j] =
+          complexMultiplication(amplitudes[i], complexConjugate(amplitudes[j]));
+    }
+  }
+
+  return densityMatrix;
+}
+
+bool partialTraceIsPure(const Statevector& sv,
+                        const std::vector<size_t>& traceOut) {
+  const auto traceMatrix = getPartialTraceFromStateVector(sv, traceOut);
+  const auto trace = getTraceOfSquare(traceMatrix);
+  const double epsilon = 0.00000001;
+  return trace.imaginary < epsilon && trace.imaginary > -epsilon &&
+         (trace.real - 1) < epsilon && (trace.real - 1) > -epsilon;
+}
+
+std::vector<std::vector<Complex>>
+getPartialTraceFromStateVector(const Statevector& sv,
+                               const std::vector<size_t>& traceOut) {
+  const auto traceSize = 1ULL << (sv.numQubits - traceOut.size());
+  const Span<Complex> amplitudes(sv.amplitudes, sv.numStates);
+  std::vector<std::vector<Complex>> traceMatrix(
+      traceSize, std::vector<Complex>(traceSize, {0, 0}));
+  for (size_t i = 0; i < sv.numStates; i++) {
+    for (size_t j = 0; j < sv.numStates; j++) {
+      const auto split1 = splitBitString(i, sv.numQubits, traceOut);
+      const auto split2 = splitBitString(j, sv.numQubits, traceOut);
+      if (split1.first != split2.first) {
+        continue;
+      }
+      const auto product = complexMultiplication(amplitudes[i], amplitudes[j]);
+      const auto row = split1.second;
+      const auto col = split2.second;
+      traceMatrix[row][col] = complexAddition(traceMatrix[row][col], product);
+    }
+  }
+  return traceMatrix;
+}
+
+Eigen::MatrixXcd // NOLINT
+toEigenMatrix(const std::vector<std::vector<Complex>>& matrix) {
+  Eigen::MatrixXcd mat(static_cast<int64_t>(matrix.size()),  // NOLINT
+                       static_cast<int64_t>(matrix.size())); // NOLINT
+  for (size_t i = 0; i < matrix.size(); i++) {
+    for (size_t j = 0; j < matrix.size(); j++) {
+      mat(static_cast<int64_t>(i), static_cast<int64_t>(j)) = {
+          matrix[i][j].real, matrix[i][j].imaginary};
+    }
+  }
+  return mat;
+}
+
+double complexMagnitude(Complex& c) {
+  return std::sqrt(c.real * c.real + c.imaginary * c.imaginary);
+}
+
+std::vector<Complex>
+getSubStateVectorAmplitudes(const Statevector& sv,
+                            const std::vector<size_t>& qubits) {
+  std::vector<size_t> otherQubits;
+  for (size_t i = 0; i < sv.numQubits; i++) {
+    if (std::find(qubits.begin(), qubits.end(), i) == qubits.end()) {
+      otherQubits.push_back(i);
+    }
+  }
+
+  const auto traced = getPartialTraceFromStateVector(sv, otherQubits);
+
+  // Create Eigen3 Matrix
+  const auto mat = toEigenMatrix(traced);
+
+  const Eigen::ComplexEigenSolver<Eigen::MatrixXcd> solver(mat); // NOLINT
+
+  const auto& vectors = solver.eigenvectors();
+  const auto& values = solver.eigenvalues();
+  const auto epsilon = 0.000001;
+  int index = -1;
+  for (int i = 0; i < values.size(); i++) {
+    if (values[i].imag() < -epsilon || values[i].imag() > epsilon) {
+      continue;
+    }
+    if (values[i].real() - 1 < -epsilon || values[i].real() - 1 > epsilon) {
+      continue;
+    }
+    index = i;
+  }
+
+  if (index == -1) {
+    throw std::runtime_error("No valid index found");
+  }
+
+  std::vector<Complex> amplitudes;
+
+  for (size_t i = 0; i < traced.size(); i++) {
+    amplitudes.push_back({vectors(static_cast<int>(i), index).real(),
+                          vectors(static_cast<int>(i), index).imag()});
+  }
+  return amplitudes;
+}
+
+/**
+ * @brief Generate a string representation of a double without trailing zeros.
+ *
+ * @param d The double to convert to a string.
+ * @return The string representation of the double.
+ */
+std::string doubleToString(const double d) {
+  auto string = std::to_string(d);
+  while (string.back() == '0') {
+    string.pop_back();
+  }
+  if (string.back() == '.') {
+    string.pop_back();
+  }
+  return string;
+}
+
+std::string complexToString(const Complex& c) {
+  const double epsilon = 0.0000001;
+  if (c.imaginary < epsilon && c.imaginary > -epsilon) {
+    return doubleToString(c.real);
+  }
+  if (c.real < epsilon && c.real > -epsilon) {
+    return doubleToString(c.imaginary) + "i";
+  }
+  return doubleToString(c.real) + " + " + doubleToString(c.imaginary) + "i";
+}

--- a/src/common/ComplexMathematics.cpp
+++ b/src/common/ComplexMathematics.cpp
@@ -181,7 +181,7 @@ bool partialTraceIsPure(const Statevector& sv,
                         const std::vector<size_t>& traceOut) {
   const auto traceMatrix = getPartialTraceFromStateVector(sv, traceOut);
   const auto trace = getTraceOfSquare(traceMatrix);
-  const double epsilon = 0.00000001;
+  const double epsilon = 0.0001;
   return trace.imaginary < epsilon && trace.imaginary > -epsilon &&
          (trace.real - 1) < epsilon && (trace.real - 1) > -epsilon;
 }
@@ -245,7 +245,7 @@ getSubStateVectorAmplitudes(const Statevector& sv,
 
   const auto& vectors = solver.eigenvectors();
   const auto& values = solver.eigenvalues();
-  const auto epsilon = 0.000001;
+  const auto epsilon = 0.0001;
   int index = -1;
   for (int i = 0; i < values.size(); i++) {
     if (values[i].imag() < -epsilon || values[i].imag() > epsilon) {

--- a/src/common/parsing/AssertionParsing.cpp
+++ b/src/common/parsing/AssertionParsing.cpp
@@ -109,17 +109,29 @@ std::vector<std::string> extractTargetQubits(const std::string& targetPart) {
  */
 Complex parseComplex(std::string complexString) {
   complexString = removeWhitespace(complexString);
-  auto parts = splitString(complexString, '+');
+  auto parts = splitString(complexString, '-');
+  bool negativeSplit = true;
+  if (parts[0].empty()) {
+    parts.erase(parts.begin());
+    parts[0] = "-" + parts[0];
+  }
+  if (parts.size() == 1) {
+    negativeSplit = false;
+    parts = splitString(complexString, '+');
+  }
   double real = 0;
   double imaginary = 0;
+  bool first = true;
   for (auto& part : parts) {
     if (part.find('i') != std::string::npos ||
         part.find('j') != std::string::npos) {
       imaginary +=
-          std::stod(replaceString(replaceString(part, "i", ""), "j", ""));
+          std::stod(replaceString(replaceString(part, "i", ""), "j", "")) *
+          (negativeSplit && !first ? -1 : 1);
     } else {
-      real += std::stod(part);
+      real += std::stod(part) * (negativeSplit && !first ? -1 : 1);
     }
+    first = false;
   }
   return {real, imaginary};
 }

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <string>
 
-bool doesCommuteEnt(const EntanglementAssertion* assertion,
+bool doesCommuteEnt(const EntanglementAssertion* assertion, // NOLINT
                     const std::string& instruction) {
   const auto targets = parseParameters(instruction);
   return targets.size() < 2; // If the instruction does not target at least two
@@ -16,7 +16,7 @@ bool doesCommuteEnt(const EntanglementAssertion* assertion,
   // In theory, even more could be done here, but for now we leave it like this.
 }
 
-bool doesCommuteSup(const SuperpositionAssertion* assertion,
+bool doesCommuteSup(const SuperpositionAssertion* assertion, // NOLINT
                     const std::string& instruction) {
   const auto targets = parseParameters(instruction);
   if (targets.size() >= 2) {
@@ -24,13 +24,11 @@ bool doesCommuteSup(const SuperpositionAssertion* assertion,
                   // influence the superposition of the qubits.
   }
   const auto name = splitString(trim(instruction), ' ')[0];
-  if (name == "x" || name == "y" || name == "z" || name == "s" || name == "t" ||
-      name == "sdg" || name == "tdg") {
-    return true; // Most common Single-qubit gates commute with superposition
-                 // assertions.
-  }
-  return false; // For other gates, it's hard to say how they would influence
-                // the superposition of the qubits.
+  return (name == "x" || name == "y" || name == "z" || name == "s" ||
+          name == "t" || name == "sdg" || name == "tdg");
+  // Most common Single-qubit gates commute with superposition assertions.
+  // For other gates, it's hard to say how they would influence
+  // the superposition of the qubits.
 }
 
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -70,7 +70,14 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
     return true; // Order of function definitions does not matter.
   }
   if (isVariableDeclaration(code)) {
-    return true; // Order of unrelated variable declarations does not matter.
+    // Order of unrelated variable declarations does not matter.
+    const auto targets = parseParameters(code);
+    const auto registerName = variableBaseName(targets[0]);
+    return std::none_of(assertion->getTargetQubits().begin(),
+                        assertion->getTargetQubits().end(),
+                        [&registerName](const auto& target) {
+                          return registerName == variableBaseName(target);
+                        });
   }
   if (isMeasurement(code)) {
     return false; // Assertions should never be moved above measurements.

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -68,6 +68,13 @@ static const std::vector<std::function<CommutationResult(
         OTHER_1Q_GATE_INVARIANTS,
 };
 
+/**
+ * @brief Check if an entanglement assertion commutes with an instruction.
+ * @param assertion The assertion to check.
+ * @param instructionName The name of the instruction to check.
+ * @param targets The targets of the instruction.
+ * @return True if the assertion commutes with the instruction, false otherwise.
+ */
 bool doesCommuteEnt(const EntanglementAssertion* assertion,
                     const std::string& instructionName,
                     const std::vector<std::string>& targets) {
@@ -80,6 +87,13 @@ bool doesCommuteEnt(const EntanglementAssertion* assertion,
   return false;
 }
 
+/**
+ * @brief Check if a superposition assertion commutes with an instruction.
+ * @param assertion The assertion to check.
+ * @param instructionName The name of the instruction to check.
+ * @param targets The targets of the instruction.
+ * @return True if the assertion commutes with the instruction, false otherwise.
+ */
 bool doesCommuteSup(const SuperpositionAssertion* assertion,
                     const std::string& instructionName,
                     const std::vector<std::string>& targets) {
@@ -92,6 +106,12 @@ bool doesCommuteSup(const SuperpositionAssertion* assertion,
   return false;
 }
 
+/**
+ * @brief Check if a general assertion commutes with an instruction.
+ * @param assertion The assertion to check.
+ * @param instruction The instruction to check in string form.
+ * @return True if the assertion commutes with the instruction, false otherwise.
+ */
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const std::string& instruction) {
   const auto targets = parseParameters(instruction);

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -129,7 +129,8 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const Instruction& instruction) {
   const auto& code = instruction.code;
   if (instruction.assertion != nullptr) {
-    return false; // The order of assertions should remain stable.
+    return true; // Allow lifting over other assertions so a stuck assertion
+                 // above will not also fixate all assertions below it.
   }
   if (instruction.isFunctionDefinition) {
     return true; // Order of function definitions does not matter.

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -167,17 +167,18 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
     });
   }
 
-  if (instruction.isFunctionCall) {
-    return false; // TODO this is a bit more complex
-  }
-
   const auto& assertionTargets = assertion->getTargetQubits();
   const auto& instructionTargets = instruction.targets;
   if (std::none_of(assertionTargets.begin(), assertionTargets.end(),
                    [&instructionTargets](const auto& target) {
-                     return std::find(instructionTargets.begin(),
-                                      instructionTargets.end(),
-                                      target) != instructionTargets.end();
+                     return std::any_of(
+                         instructionTargets.begin(), instructionTargets.end(),
+                         [&target](const std::string& instrTarget) {
+                           return (instrTarget.find('[') != std::string::npos &&
+                                   instrTarget == target) ||
+                                  (instrTarget.find('[') == std::string::npos &&
+                                   variableBaseName(target) == instrTarget);
+                         });
                    })) {
     return true; // If the assertion does not target any of the qubits in the
                  // instruction, the order does not matter.

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <string>
 
-bool doesCommuteEnt(const std::unique_ptr<EntanglementAssertion>& assertion,
+bool doesCommuteEnt(const EntanglementAssertion* assertion,
                     const std::string& instruction) {
   const auto targets = parseParameters(instruction);
   return targets.size() < 2; // If the instruction does not target at least two
@@ -16,7 +16,7 @@ bool doesCommuteEnt(const std::unique_ptr<EntanglementAssertion>& assertion,
   // In theory, even more could be done here, but for now we leave it like this.
 }
 
-bool doesCommuteSup(const std::unique_ptr<SuperpositionAssertion>& assertion,
+bool doesCommuteSup(const SuperpositionAssertion* assertion,
                     const std::string& instruction) {
   const auto targets = parseParameters(instruction);
   if (targets.size() >= 2) {
@@ -40,16 +40,16 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
   }
 
   if (assertion->getType() == AssertionType::Entanglement) {
-    return doesCommuteEnt(
-        std::unique_ptr<EntanglementAssertion>(
-            dynamic_cast<EntanglementAssertion*>(assertion.get())),
-        instruction);
+    const auto* entAssertion =
+        dynamic_cast<EntanglementAssertion*>(assertion.get());
+    const auto result = doesCommuteEnt(entAssertion, instruction);
+    return result;
   }
   if (assertion->getType() == AssertionType::Superposition) {
-    return doesCommuteSup(
-        std::unique_ptr<SuperpositionAssertion>(
-            dynamic_cast<SuperpositionAssertion*>(assertion.get())),
-        instruction);
+    const auto* supAssertion =
+        dynamic_cast<SuperpositionAssertion*>(assertion.get());
+    const auto result = doesCommuteSup(supAssertion, instruction);
+    return result;
   }
   if (assertion->getType() == AssertionType::CircuitEquality ||
       assertion->getType() == AssertionType::StatevectorEquality) {
@@ -57,6 +57,7 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
     // dependent operation will (likely) change the state of the qubits.
     return false;
   }
+  return false;
 }
 
 bool doesCommute(const std::unique_ptr<Assertion>& assertion,

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -11,60 +11,59 @@
 #include <vector>
 
 #define YES(expression)                                                        \
-  (expression) ? CommutativityResult::Commutes : CommutativityResult::Unknown;
+  (expression) ? CommutationResult::Commutes : CommutationResult::Unknown;
 #define NO(expression)                                                         \
-  (expression) ? CommutativityResult::DoesNotCommute                           \
-               : CommutativityResult::Unknown;
+  (expression) ? CommutationResult::DoesNotCommute : CommutationResult::Unknown;
 
 //------------------------------------------------------------------------------
 // General rules
 //------------------------------------------------------------------------------
 
 // Barrier instructions will not remove or create entanglement or superposition
-static COMMUTATIVITY_RULE_GENERAL(BARRIER, YES(instructionName == "barrier"));
+static COMMUTATION_RULE_GENERAL(BARRIER, YES(instructionName == "barrier"));
 
 //------------------------------------------------------------------------------
 // Entanglement rules
 //------------------------------------------------------------------------------
 
 // 1-qubit gates will not remove or create entanglement
-static COMMUTATIVITY_RULE_ENT(TWO_OR_MORE_TARGETS, YES(arguments.size() < 2));
+static COMMUTATION_RULE_ENT(TWO_OR_MORE_TARGETS, YES(arguments.size() < 2));
 
 //------------------------------------------------------------------------------
 // Superposition rules
 //------------------------------------------------------------------------------
 
 // Pauli-Instructions will not remove or create superposition
-static COMMUTATIVITY_RULE_SUP(PAULI_INVARIANT, YES(instructionName == "x" ||
-                                                   instructionName == "y" ||
-                                                   instructionName == "z"));
+static COMMUTATION_RULE_SUP(PAULI_INVARIANT, YES(instructionName == "x" ||
+                                                 instructionName == "y" ||
+                                                 instructionName == "z"));
 
 // `S` and `T` gates will not remove or create superposition
-static COMMUTATIVITY_RULE_SUP(OTHER_1Q_GATE_INVARIANTS,
-                              YES(instructionName == "s" ||
-                                  instructionName == "t" ||
-                                  instructionName == "sdg" ||
-                                  instructionName == "tdg"));
+static COMMUTATION_RULE_SUP(OTHER_1Q_GATE_INVARIANTS,
+                            YES(instructionName == "s" ||
+                                instructionName == "t" ||
+                                instructionName == "sdg" ||
+                                instructionName == "tdg"));
 
 //------------------------------------------------------------------------------
 
-static const std::vector<std::function<CommutativityResult(
+static const std::vector<std::function<CommutationResult(
     const Assertion*, const std::string&, const std::vector<std::string>&)>>
-    GENERAL_COMMUTATIVITY_RULES = {
+    GENERAL_COMMUTATION_RULES = {
         BARRIER,
 };
 
-static const std::vector<std::function<CommutativityResult(
+static const std::vector<std::function<CommutationResult(
     const EntanglementAssertion*, const std::string&,
     const std::vector<std::string>&)>>
-    ENTANGLEMENT_COMMUTATIVITY_RULES = {
+    ENTANGLEMENT_COMMUTATION_RULES = {
         TWO_OR_MORE_TARGETS,
 };
 
-static const std::vector<std::function<CommutativityResult(
+static const std::vector<std::function<CommutationResult(
     const SuperpositionAssertion*, const std::string&,
     const std::vector<std::string>&)>>
-    SUPERPOSITION_COMMUTATIVITY_RULES = {
+    SUPERPOSITION_COMMUTATION_RULES = {
         PAULI_INVARIANT,
         OTHER_1Q_GATE_INVARIANTS,
 };
@@ -72,10 +71,10 @@ static const std::vector<std::function<CommutativityResult(
 bool doesCommuteEnt(const EntanglementAssertion* assertion,
                     const std::string& instructionName,
                     const std::vector<std::string>& targets) {
-  for (const auto& rule : ENTANGLEMENT_COMMUTATIVITY_RULES) {
+  for (const auto& rule : ENTANGLEMENT_COMMUTATION_RULES) {
     const auto result = rule(assertion, instructionName, targets);
-    if (result != CommutativityResult::Unknown) {
-      return result == CommutativityResult::Commutes;
+    if (result != CommutationResult::Unknown) {
+      return result == CommutationResult::Commutes;
     }
   }
   return false;
@@ -84,10 +83,10 @@ bool doesCommuteEnt(const EntanglementAssertion* assertion,
 bool doesCommuteSup(const SuperpositionAssertion* assertion,
                     const std::string& instructionName,
                     const std::vector<std::string>& targets) {
-  for (const auto& rule : SUPERPOSITION_COMMUTATIVITY_RULES) {
+  for (const auto& rule : SUPERPOSITION_COMMUTATION_RULES) {
     const auto result = rule(assertion, instructionName, targets);
-    if (result != CommutativityResult::Unknown) {
-      return result == CommutativityResult::Commutes;
+    if (result != CommutationResult::Unknown) {
+      return result == CommutationResult::Commutes;
     }
   }
   return false;
@@ -97,10 +96,10 @@ bool doesCommute(const std::unique_ptr<Assertion>& assertion,
                  const std::string& instruction) {
   const auto targets = parseParameters(instruction);
   const auto instructionName = splitString(trim(instruction), ' ')[0];
-  for (const auto& rule : GENERAL_COMMUTATIVITY_RULES) {
+  for (const auto& rule : GENERAL_COMMUTATION_RULES) {
     const auto result = rule(assertion.get(), instructionName, targets);
-    if (result != CommutativityResult::Unknown) {
-      return result == CommutativityResult::Commutes;
+    if (result != CommutationResult::Unknown) {
+      return result == CommutationResult::Commutes;
     }
   }
 

--- a/src/common/parsing/AssertionTools.cpp
+++ b/src/common/parsing/AssertionTools.cpp
@@ -1,0 +1,94 @@
+#include "common/parsing/AssertionTools.hpp"
+
+#include "common/parsing/AssertionParsing.hpp"
+#include "common/parsing/CodePreprocessing.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+bool doesCommuteEnt(const std::unique_ptr<EntanglementAssertion>& assertion,
+                    const std::string& instruction) {
+  return false; // TODO implement
+}
+
+bool doesCommuteSup(const std::unique_ptr<SuperpositionAssertion>& assertion,
+                    const std::string& instruction) {
+  return false; // TODO implement
+}
+
+bool doesCommute(const std::unique_ptr<Assertion>& assertion,
+                 const std::string& instruction) {
+  if (isBarrier(instruction)) {
+    return true; // Order of barriers does not matter.
+  }
+
+  if (assertion->getType() == AssertionType::Entanglement) {
+    return doesCommuteEnt(
+        std::unique_ptr<EntanglementAssertion>(
+            dynamic_cast<EntanglementAssertion*>(assertion.get())),
+        instruction);
+  }
+  if (assertion->getType() == AssertionType::Superposition) {
+    return doesCommuteSup(
+        std::unique_ptr<SuperpositionAssertion>(
+            dynamic_cast<SuperpositionAssertion*>(assertion.get())),
+        instruction);
+  }
+  if (assertion->getType() == AssertionType::CircuitEquality ||
+      assertion->getType() == AssertionType::StatevectorEquality) {
+    // Equality assertions are not commutative with dependent operations, as any
+    // dependent operation will (likely) change the state of the qubits.
+    return false;
+  }
+}
+
+bool doesCommute(const std::unique_ptr<Assertion>& assertion,
+                 const Instruction& instruction) {
+  const auto& code = instruction.code;
+  if (instruction.assertion != nullptr) {
+    return false; // The order of assertions should remain stable.
+  }
+  if (instruction.isFunctionDefinition) {
+    return true; // Order of function definitions does not matter.
+  }
+  if (isVariableDeclaration(code)) {
+    return true; // Order of unrelated variable declarations does not matter.
+  }
+  if (isMeasurement(code)) {
+    return false; // Assertions should never be moved above measurements.
+                  // [UNLESS measurement and assertion targets are not
+                  // entangled, but this cannot be checked in advance.]
+  }
+  if (isReset(code)) {
+    return false; // Assertions should never be moved above resets. [UNLESS
+                  // measurement and assertion targets are not entangled, but
+                  // this cannot be checked in advance.]
+  }
+  if (isClassicControlledGate(code)) {
+    // For classic-controlled gates, the classical parts do not matter, so we
+    // only need to focus on the quantum parts.
+    const auto c = parseClassicControlledGate(code).operations;
+    return std::all_of(c.begin(), c.end(), [&assertion](const auto& operation) {
+      return doesCommute(assertion, operation);
+    });
+  }
+
+  if (instruction.isFunctionCall) {
+    return false; // TODO this is a bit more complex
+  }
+
+  const auto& assertionTargets = assertion->getTargetQubits();
+  const auto& instructionTargets = instruction.targets;
+  if (std::none_of(assertionTargets.begin(), assertionTargets.end(),
+                   [&instructionTargets](const auto& target) {
+                     return std::find(instructionTargets.begin(),
+                                      instructionTargets.end(),
+                                      target) != instructionTargets.end();
+                   })) {
+    return true; // If the assertion does not target any of the qubits in the
+                 // instruction, the order does not matter.
+  }
+
+  return doesCommute(assertion, instruction.code);
+}

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -113,7 +113,7 @@ bool isClassicControlledGate(const std::string& line) {
 
 ClassicControlledGate parseClassicControlledGate(const std::string& code) {
   std::stringstream condition;
-  const auto codeSanitized = replaceString(removeWhitespace(code), "if", "");
+  const auto codeSanitized = trim(replaceString(code, "if", ""));
   int openBrackets = 0;
   size_t i = 0;
   for (; i < codeSanitized.size(); i++) {
@@ -130,7 +130,7 @@ ClassicControlledGate parseClassicControlledGate(const std::string& code) {
   }
   auto rest = codeSanitized.substr(i + 1, codeSanitized.size() - i - 1);
   rest = replaceString(replaceString(rest, "}", ""), "{", "");
-  const auto operations = splitString(rest, ';');
+  const auto operations = splitString(rest, ';', false);
   return {condition.str(), operations};
 }
 

--- a/src/common/parsing/CodePreprocessing.cpp
+++ b/src/common/parsing/CodePreprocessing.cpp
@@ -169,11 +169,6 @@ FunctionDefinition parseFunctionDefinition(const std::string& signature) {
   return {name, parameters};
 }
 
-/**
- * @brief Parse the parameters or arguments from a given instruction.
- * @param instruction The instruction to parse.
- * @return A vector containing the parsed parameters.
- */
 std::vector<std::string> parseParameters(const std::string& instruction) {
   if (isFunctionDefinition(instruction)) {
     const auto fd = parseFunctionDefinition(instruction);

--- a/src/common/parsing/Utils.cpp
+++ b/src/common/parsing/Utils.cpp
@@ -21,13 +21,15 @@ bool startsWith(const std::string& str, const std::string& prefix) {
   return str.compare(0, prefix.size(), prefix) == 0;
 }
 
-std::vector<std::string> splitString(const std::string& text, char delimiter) {
+std::vector<std::string> splitString(const std::string& text, char delimiter,
+                                     bool includeEmpty) {
   const std::vector<char> delimiters{delimiter};
-  return splitString(text, delimiters);
+  return splitString(text, delimiters, includeEmpty);
 }
 
 std::vector<std::string> splitString(const std::string& text,
-                                     const std::vector<char>& delimiters) {
+                                     const std::vector<char>& delimiters,
+                                     bool includeEmpty) {
   std::vector<std::string> result;
   size_t pos = 0;
   while (true) {
@@ -39,10 +41,14 @@ std::vector<std::string> splitString(const std::string& text,
     if (min == std::string::npos) {
       break;
     }
-    result.push_back(text.substr(pos, min - pos));
+    if (min > pos || includeEmpty) {
+      result.push_back(text.substr(pos, min - pos));
+    }
     pos = min + 1;
   }
-  result.push_back(text.substr(pos, text.length() - pos));
+  if (text.length() > pos || includeEmpty) {
+    result.push_back(text.substr(pos, text.length() - pos));
+  }
   return result;
 }
 
@@ -72,4 +78,8 @@ bool variablesEqual(const std::string& v1, const std::string& v2) {
     return variablesEqual(splitString(v2, '[')[0], v1);
   }
   return v1 == v2;
+}
+
+std::string variableBaseName(const std::string& v) {
+  return splitString(v, '[')[0];
 }

--- a/src/mqt/debugger/pydebugger.pyi
+++ b/src/mqt/debugger/pydebugger.pyi
@@ -478,6 +478,26 @@ class Diagnostics:
             list[ErrorCause]: A list of potential error causes encountered during execution.
         """
 
+    def suggest_assertion_movements(self) -> tuple[int, int]:
+        """Suggest movements of assertions to better positions.
+
+        Each entry of the resulting list consists of the original position of the assertion, followed by its new
+        suggested position.
+
+        Returns:
+            list[tuple[int, int]]: A list of moved assertions.
+        """
+
+    def suggest_new_assertions(self) -> tuple[int, str]:
+        """Suggest new assertions to be added to the program.
+
+        Each entry of the resulting list consists of the suggested position for the new assertion, followed by its
+        string representation.
+
+        Returns:
+          list[tupke[int, str]]: A list of new assertions.
+        """
+
 def create_ddsim_simulation_state() -> SimulationState:
     """Creates a new `SimulationState` instance using the DD backend for simulation and the OpenQASM language as input format.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,8 @@ package_add_test(
   test_diagnostics.cpp
   test_custom_code.cpp
   test_parsing.cpp
-  test_assertion_movement.cpp)
+  test_assertion_movement.cpp
+  test_assertion_creation.cpp)
 
 # set include directories
 target_include_directories(mqt_debugger_test PUBLIC ${PROJECT_SOURCE_DIR}/test/utils)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 package_add_test(
   mqt_debugger_test
   MQT::Debugger
-  common_fixtures.cpp
   utils_test.cpp
   test_utility.cpp
   test_simulation.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,15 @@
 package_add_test(
   mqt_debugger_test
   MQT::Debugger
+  common_fixtures.cpp
   utils_test.cpp
   test_utility.cpp
   test_simulation.cpp
   test_data_retrieval.cpp
   test_diagnostics.cpp
   test_custom_code.cpp
-  test_parsing.cpp)
+  test_parsing.cpp
+  test_assertion_movement.cpp)
 
 # set include directories
 target_include_directories(mqt_debugger_test PUBLIC ${PROJECT_SOURCE_DIR}/test/utils)

--- a/test/common_fixtures.cpp
+++ b/test/common_fixtures.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file common_fixtures.cpp
+ * @brief Provides common fixture base classes for other tests.
+ */
+
+#include "backend/dd/DDSimDebug.hpp"
+#include "backend/dd/DDSimDiagnostics.hpp"
+#include "backend/debug.h"
+#include "backend/diagnostics.h"
+#include "utils_test.hpp"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+
+/**
+ * @brief Fixture that loads custom code.
+ *
+ * This fixture sets up a DDSimulationState and provides the method
+ * `loadCode` to load custom code into the state.
+ */
+class CustomCodeFixture : public testing::Test {
+protected:
+  void SetUp() override {
+    createDDSimulationState(&ddState);
+    state = &ddState.interface;
+    diagnostics = state->getDiagnostics(state);
+  }
+
+  /**
+   * @brief The DDSimulationState to use for testing.
+   */
+  DDSimulationState ddState;
+  /**
+   * @brief The DDSimulationState to use for testing.
+   */
+  Diagnostics* diagnostics;
+  /**
+   * @brief A reference to the SimulationState interface for easier access.
+   */
+  SimulationState* state = nullptr;
+
+  /**
+   * @brief The full code to load into the state.
+   */
+  std::string fullCode;
+
+  /**
+   * @brief The code provided by the user explicitly.
+   */
+  std::string userCode;
+
+  /*
+   * @brief Load custom code into the state.
+   *
+   * Classical and Quantum registers of the given size are created automatically
+   * with the names `c` and `q`. Therefore, the first instruction in the
+   * provided code will have instruction index 2, as 0 and 1 are reserved for
+   * the registers.\n\n
+   *
+   * At least one classical and quantum bit will always be created, even if the
+   * given number is less than 1.
+   *
+   * @param numQubits The number of qubits to create.
+   * @param numClassics The number of classical bits to create.
+   * @param code The code to load into the state.
+   * @param shouldFail Asserts whether the code should fail to load (i.e., due
+   * to an expected error).
+   * @param preamble The preamble to add to the code before loading declaring
+   * the registers (e.g., library imports).
+   */
+  void loadCode(size_t numQubits, size_t numClassics, const char* code,
+                bool shouldFail = false, const char* preamble = "") {
+    if (numQubits < 1) {
+      numQubits = 1;
+    }
+    if (numClassics < 1) {
+      numClassics = 1;
+    }
+    std::ostringstream ss;
+
+    ss << preamble;
+
+    ss << "qreg q[" << numQubits << "];\n";
+    ss << "creg c[" << numClassics << "];\n";
+
+    ss << code;
+
+    userCode = code;
+    fullCode = ss.str();
+    ASSERT_EQ(state->loadCode(state, fullCode.c_str()),
+              shouldFail ? ERROR : OK);
+  }
+
+  /**
+   * @brief Continue execution until the given instruction is reached.
+   *
+   * Instruction numbers start with 0 for the first instruction defined in the
+   * user code.
+   *
+   * @param instruction The instruction to forward to.
+   */
+  void forwardTo(size_t instruction) {
+    instruction += 2; // Skip the qreg and creg declarations
+    size_t currentInstruction = state->getCurrentInstruction(state);
+    while (currentInstruction < instruction) {
+      state->stepForward(state);
+      currentInstruction = state->getCurrentInstruction(state);
+    }
+  }
+};
+
+/**
+ * @brief Fixture that allows code to be loaded from a specific file.
+ *
+ * The file must be located in the `circuits` directory.
+ */
+class LoadFromFileFixture : public virtual testing::Test {
+protected:
+  void SetUp() override {
+    createDDSimulationState(&ddState);
+    state = &ddState.interface;
+    diagnostics = state->getDiagnostics(state);
+  }
+
+  /**
+   * @brief The DDSimulationState to use for testing.
+   */
+  DDSimulationState ddState;
+  /**
+   * @brief A reference to the SimulationState interface for easier access.
+   */
+  SimulationState* state = nullptr;
+  /**
+   * @brief A reference to the Diagnostics interface for easier access.
+   */
+  Diagnostics* diagnostics = nullptr;
+
+  /**
+   * @brief Load the code from the file with the given name.
+   *
+   * The given file should be located in the `circuits` directory and use the
+   * `.qasm` extension.
+   * @param testName The name of the file to load (not including the `circuits`
+   * directory path and the extension).
+   */
+  void loadFromFile(const std::string& testName) {
+    const auto code = readFromCircuitsPath(testName);
+    state->loadCode(state, code.c_str());
+  }
+
+  /**
+   * @brief Continue execution until the given instruction is reached.
+   *
+   * @param instruction The instruction to forward to.
+   */
+  void forwardTo(size_t instruction) {
+    size_t currentInstruction = state->getCurrentInstruction(state);
+    while (currentInstruction < instruction) {
+      state->stepForward(state);
+      currentInstruction = state->getCurrentInstruction(state);
+    }
+  }
+};

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -115,3 +115,15 @@ TEST_F(AssertionCreationTest, DontSplitEntangledEqualityAssertion) {
   const std::set<std::pair<size_t, std::string>> expected = {};
   checkNewAssertions(expected, 1);
 }
+
+TEST_F(AssertionCreationTest, SplitEqualityAssertionRounded) {
+  loadCode(3, 1, R"(
+  assert-eq 0.99999, q[0], q[1], q[2] { 0, 0, 0, 0.70711, 0, 0, -0, -0.70711 }
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {
+      {0, "assert-eq 0.99999, q[0] { 0, 1 }\n"},
+      {0, "assert-eq 0.99999, q[1] { 0, 1 }\n"},
+      {0, "assert-eq 0.99999, q[2] { 0.707107, -0.707107 }\n"}};
+  checkNewAssertions(expected, 1);
+}

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -84,3 +84,36 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
       {3, "assert-ent q[1], q[2];\n"}};
   checkNewAssertions(expected, 1);
 }
+
+TEST_F(AssertionCreationTest, SplitEqualityAssertion) {
+  loadCode(3, 1, R"(
+  assert-eq q[0], q[1] { 1, 0, 0, 0 }
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {
+      {0, "assert-eq q[0] { 1, 0 }\n"},
+      {0, "assert-eq q[1] { 1, 0 }\n"}
+  };
+  checkNewAssertions(expected, 1);
+}
+
+TEST_F(AssertionCreationTest, SplitEqualityAssertionMultipleAmplitudes) {
+  loadCode(3, 1, R"(
+  assert-eq q[0], q[1] { 0.5, 0.5, 0.5, 0.5 }
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {
+      {0, "assert-eq 0.99999, q[0] { 0.70711, 0.70711 }\n"},
+      {0, "assert-eq 0.99999, q[1] { 0.70711, 0.70711 }\n"}
+  };
+  checkNewAssertions(expected, 1);
+}
+
+TEST_F(AssertionCreationTest, DontSplitEntangledEqualityAssertion) {
+  loadCode(3, 1, R"(
+  assert-eq 0.9, q[0], q[1] { 0.707, 0, 0, 0.707 }
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {};
+  checkNewAssertions(expected, 1);
+}

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -91,9 +91,7 @@ TEST_F(AssertionCreationTest, SplitEqualityAssertion) {
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {0, "assert-eq q[0] { 1, 0 }\n"},
-      {0, "assert-eq q[1] { 1, 0 }\n"}
-  };
+      {0, "assert-eq q[0] { 1, 0 }\n"}, {0, "assert-eq q[1] { 1, 0 }\n"}};
   checkNewAssertions(expected, 1);
 }
 
@@ -104,8 +102,7 @@ TEST_F(AssertionCreationTest, SplitEqualityAssertionMultipleAmplitudes) {
 
   const std::set<std::pair<size_t, std::string>> expected = {
       {0, "assert-eq 0.99999, q[0] { 0.70711, 0.70711 }\n"},
-      {0, "assert-eq 0.99999, q[1] { 0.70711, 0.70711 }\n"}
-  };
+      {0, "assert-eq 0.99999, q[1] { 0.70711, 0.70711 }\n"}};
   checkNewAssertions(expected, 1);
 }
 

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -26,6 +26,12 @@
  */
 class AssertionCreationTest : public CustomCodeFixture {
 public:
+  /**
+   * @brief Checks a set of created assertions against the expected ones.
+   *
+   * @param expected The assertions expected to be created.
+   * @param expectedErrors The expected number of errors.
+   */
   void
   checkNewAssertions(const std::set<std::pair<size_t, std::string>>& expected,
                      size_t expectedErrors) {
@@ -57,6 +63,12 @@ public:
   }
 };
 
+/**
+ * @test Tests the creation of new entanglement assertions from bigger ones.
+ *
+ * The test starts with an assertion over `q[0]`, `q[1]`, and `q[2]` and should
+ * end with three new assertions: `q[0], q[1]`; `q[0], q[2]`; and `q[1], q[2]`.
+ */
 TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromBigAssertion) {
   loadCode(3, 3, R"(
   h q[0];
@@ -72,6 +84,13 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromBigAssertion) {
   checkNewAssertions(expected, 1);
 }
 
+/**
+ * @test Tests the creation of new entanglement assertions from
+ * a simple interaction graph.
+ *
+ * The test starts with an assertion over `q[0]` and `q[2]` and should generate
+ * two new assertions: `q[0], q[1]`; and `q[1], q[2]`.
+ */
 TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
   loadCode(3, 3, R"(
   h q[0];
@@ -85,6 +104,13 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
   checkNewAssertions(expected, 1);
 }
 
+/**
+ * @test Tests the creation of new equality assertions by splitting a bigger
+ * one.
+ *
+ * The test starts with an assertion over `q[0]` and `q[1]` and should generate
+ * one new assertions for each qubit.
+ */
 TEST_F(AssertionCreationTest, SplitEqualityAssertion) {
   loadCode(2, 1, R"(
   x q[0];
@@ -96,6 +122,13 @@ TEST_F(AssertionCreationTest, SplitEqualityAssertion) {
   checkNewAssertions(expected, 1);
 }
 
+/**
+ * @test Tests the creation of new equality assertions by splitting a bigger
+ * one.
+ *
+ * The test starts with an assertion equally distributed over `q[0]` and `q[1]`
+ * and should generate one new assertions for each qubit.
+ */
 TEST_F(AssertionCreationTest, SplitEqualityAssertionMultipleAmplitudes) {
   loadCode(3, 1, R"(
   assert-eq q[0], q[1] { 0.5, 0.5, 0.5, 0.5 }
@@ -107,6 +140,10 @@ TEST_F(AssertionCreationTest, SplitEqualityAssertionMultipleAmplitudes) {
   checkNewAssertions(expected, 1);
 }
 
+/**
+ * @test Tests that the assertion creation does not split entangled equality
+ * assertions.
+ */
 TEST_F(AssertionCreationTest, DontSplitEntangledEqualityAssertion) {
   loadCode(3, 1, R"(
   assert-eq 0.9, q[0], q[1] { 0.707, 0, 0, 0.707 }
@@ -116,6 +153,9 @@ TEST_F(AssertionCreationTest, DontSplitEntangledEqualityAssertion) {
   checkNewAssertions(expected, 1);
 }
 
+/**
+ * @test Tests the creation of new equality assertions with rounding.
+ */
 TEST_F(AssertionCreationTest, SplitEqualityAssertionRounded) {
   loadCode(3, 1, R"(
   assert-eq 0.99999, q[0], q[1], q[2] { 0, 0, 0, 0.70711, 0, 0, -0, -0.70711 }

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -86,12 +86,13 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
 }
 
 TEST_F(AssertionCreationTest, SplitEqualityAssertion) {
-  loadCode(3, 1, R"(
+  loadCode(2, 1, R"(
+  x q[0];
   assert-eq q[0], q[1] { 1, 0, 0, 0 }
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {0, "assert-eq q[0] { 1, 0 }\n"}, {0, "assert-eq q[1] { 1, 0 }\n"}};
+      {1, "assert-eq q[0] { 1, 0 }\n"}, {1, "assert-eq q[1] { 1, 0 }\n"}};
   checkNewAssertions(expected, 1);
 }
 
@@ -101,8 +102,8 @@ TEST_F(AssertionCreationTest, SplitEqualityAssertionMultipleAmplitudes) {
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {0, "assert-eq 0.99999, q[0] { 0.70711, 0.70711 }\n"},
-      {0, "assert-eq 0.99999, q[1] { 0.70711, 0.70711 }\n"}};
+      {0, "assert-eq 0.99999, q[0] { 0.707107, 0.707107 }\n"},
+      {0, "assert-eq 0.99999, q[1] { 0.707107, 0.707107 }\n"}};
   checkNewAssertions(expected, 1);
 }
 

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -66,9 +66,9 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromBigAssertion) {
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {3, "assert-ent q[1], q[2]"},
-      {3, "assert-ent q[0], q[2]"},
-      {3, "assert-ent q[0], q[1]"}};
+      {3, "assert-ent q[1], q[2];\n"},
+      {3, "assert-ent q[0], q[2];\n"},
+      {3, "assert-ent q[0], q[1];\n"}};
   checkNewAssertions(expected, 1);
 }
 
@@ -81,6 +81,6 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {3, "assert-ent q[1], q[2]"}};
+      {3, "assert-ent q[1], q[2];\n"}};
   checkNewAssertions(expected, 1);
 }

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -81,7 +81,7 @@ TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
   )");
 
   const std::set<std::pair<size_t, std::string>> expected = {
-      {3, "assert-ent q[1], q[2];\n"}};
+      {2, "assert-ent q[0], q[1];\n"}, {3, "assert-ent q[1], q[2];\n"}};
   checkNewAssertions(expected, 1);
 }
 

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -3,17 +3,16 @@
  * @brief Tests the correctness of the assertion creation diagnosis methods.
  */
 
-#include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
-#include "common_fixtures.cpp"
-#include "utils_test.hpp"
+#include "common_fixtures.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <gtest/gtest.h>
-#include <sstream>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/test_assertion_creation.cpp
+++ b/test/test_assertion_creation.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file test_assertion_creation.cpp
+ * @brief Tests the correctness of the assertion creation diagnosis methods.
+ */
+
+#include "backend/dd/DDSimDebug.hpp"
+#include "backend/debug.h"
+#include "backend/diagnostics.h"
+#include "common.h"
+#include "common_fixtures.cpp"
+#include "utils_test.hpp"
+
+#include <array>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @brief Fixture for testing the correctness of assertion creation on custom
+ * code.
+ *
+ * This fixture sets up a DDSimulationState and provides the method
+ * `loadCode` to load custom code into the state.
+ */
+class AssertionCreationTest : public CustomCodeFixture {
+public:
+  void
+  checkNewAssertions(const std::set<std::pair<size_t, std::string>>& expected,
+                     size_t expectedErrors) {
+    size_t errors = 0;
+    ASSERT_EQ(state->runAll(state, &errors), OK);
+    ASSERT_EQ(errors, expectedErrors);
+    std::vector<size_t> newPositions(expected.size() + 1);
+    std::vector<std::array<char, 256>> newAssertions(expected.size() + 1);
+    std::vector<char*> newAssertionsPointers(expected.size() + 1);
+    std::transform(newAssertions.begin(), newAssertions.end(),
+                   newAssertionsPointers.begin(),
+                   [](std::array<char, 256>& arr) { return arr.data(); });
+    ASSERT_EQ(diagnostics->suggestNewAssertions(
+                  diagnostics, newPositions.data(),
+                  newAssertionsPointers.data(), newPositions.size()),
+              expected.size());
+
+    for (auto [pos, string] : expected) {
+      pos += 2;
+      bool found = false;
+      for (size_t i = 0; i < expected.size(); i++) {
+        if (newPositions[i] == pos && newAssertions[i].data() == string) {
+          found = true;
+          break;
+        }
+      }
+      ASSERT_TRUE(found) << "No new assertion found for " << (pos - 2);
+    }
+  }
+};
+
+TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromBigAssertion) {
+  loadCode(3, 3, R"(
+  h q[0];
+  cx q[0], q[1];
+  cx q[2], q[1];
+  assert-ent q[0], q[1], q[2];
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {
+      {3, "assert-ent q[1], q[2]"},
+      {3, "assert-ent q[0], q[2]"},
+      {3, "assert-ent q[0], q[1]"}};
+  checkNewAssertions(expected, 1);
+}
+
+TEST_F(AssertionCreationTest, CreateEntanglementAssertionFromTreeSimple) {
+  loadCode(3, 3, R"(
+  h q[0];
+  cx q[0], q[1];
+  cx q[2], q[1];
+  assert-ent q[0], q[2];
+  )");
+
+  const std::set<std::pair<size_t, std::string>> expected = {
+      {3, "assert-ent q[1], q[2]"}};
+  checkNewAssertions(expected, 1);
+}

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -103,17 +103,6 @@ TEST_F(AssertionMovementTest, MoveOverBarrier) {
   checkMovements(expected);
 }
 
-/*TEST_F(AssertionMovementTest, DontMoveMultipleAssertions) {
-  loadCode(3, 3, R"(
-  cx q[0], q[1];
-  assert-sup q[0];
-  assert-sup q[1];
-  )");
-
-  const std::set<std::pair<size_t, size_t>> expected;
-  checkMovements(expected);
-}*/
-
 TEST_F(AssertionMovementTest, MoveThroughFunctionDefinition) {
   loadCode(3, 3, R"(
   h q[0];

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -21,6 +21,11 @@
  */
 class AssertionMovementTest : public CustomCodeFixture {
 public:
+  /**
+   * @brief Checks a set of moved assertions against the expected ones.
+   *
+   * @param expected The assertions expected to be moved.
+   */
   void checkMovements(const std::set<std::pair<size_t, size_t>>& expected) {
     std::vector<size_t> oldPositions(expected.size() + 1);
     std::vector<size_t> newPositions(expected.size() + 1);
@@ -48,6 +53,10 @@ public:
   }
 };
 
+/**
+ * @test Test the movement of an assertion over an instruction that
+ * does not use any of the assertion's qubits.
+ */
 TEST_F(AssertionMovementTest, MoveOverIndependentInstructions) {
   loadCode(3, 3, R"(
   h q[0];
@@ -61,6 +70,10 @@ TEST_F(AssertionMovementTest, MoveOverIndependentInstructions) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the movement of an entanglement assertion over a single-qubit
+ * gate.
+ */
 TEST_F(AssertionMovementTest, MoveEntOverSingleQubit) {
   loadCode(3, 3, R"(
   h q[0];
@@ -76,6 +89,10 @@ TEST_F(AssertionMovementTest, MoveEntOverSingleQubit) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the movement of a superposition assertion over (non-)diagonal
+ * gates.
+ */
 TEST_F(AssertionMovementTest, MoveSupOverSpecificGates) {
   loadCode(3, 3, R"(
   h q[0];
@@ -92,6 +109,9 @@ TEST_F(AssertionMovementTest, MoveSupOverSpecificGates) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the movement of an assertion over a barrier instruction.
+ */
 TEST_F(AssertionMovementTest, MoveOverBarrier) {
   loadCode(3, 3, R"(
   h q[0];
@@ -103,6 +123,9 @@ TEST_F(AssertionMovementTest, MoveOverBarrier) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the movement of an assertion over a function definition.
+ */
 TEST_F(AssertionMovementTest, MoveThroughFunctionDefinition) {
   loadCode(3, 3, R"(
   h q[0];
@@ -114,6 +137,10 @@ TEST_F(AssertionMovementTest, MoveThroughFunctionDefinition) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the movement of an assertion over a variable declaration
+ * that does not use the assertion's qubits.
+ */
 TEST_F(AssertionMovementTest, MoveThroughOtherVariableDeclarations) {
   loadCode(3, 3, R"(
   h q[0];
@@ -126,6 +153,10 @@ TEST_F(AssertionMovementTest, MoveThroughOtherVariableDeclarations) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the assertion is not moved over a variable declaration
+ * that uses the assertion's qubits.
+ */
 TEST_F(AssertionMovementTest, DontMoveThroughOwnVariableDeclarations) {
   loadCode(3, 3, R"(
   h q[0];
@@ -138,6 +169,9 @@ TEST_F(AssertionMovementTest, DontMoveThroughOwnVariableDeclarations) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the assertion is not moved over a measurement.
+ */
 TEST_F(AssertionMovementTest, DontMoveThroughMeasurements) {
   loadCode(3, 3, R"(
   h q[0];
@@ -149,6 +183,9 @@ TEST_F(AssertionMovementTest, DontMoveThroughMeasurements) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the assertion is not moved over a reset.
+ */
 TEST_F(AssertionMovementTest, DontMoveThroughResets) {
   loadCode(3, 3, R"(
   h q[0];
@@ -160,6 +197,9 @@ TEST_F(AssertionMovementTest, DontMoveThroughResets) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the entanglement assertion is moved even over a custom gate call.
+ */
 TEST_F(AssertionMovementTest, MoveThroughFunctionCalls) {
   loadCode(3, 3, R"(
   cx q[0], q[1];
@@ -172,6 +212,10 @@ TEST_F(AssertionMovementTest, MoveThroughFunctionCalls) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test the superposition assertion is moved over a custom gate call
+ * that uses the same qubit.
+ */
 TEST_F(AssertionMovementTest, DontMoveThroughRelatedFunctionCall) {
   loadCode(3, 3, R"(
   h q[0];
@@ -184,6 +228,10 @@ TEST_F(AssertionMovementTest, DontMoveThroughRelatedFunctionCall) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that an assertion is not moved over an instruction
+ * that broadcasts to multiple qubits, including the assertion's qubit.
+ */
 TEST_F(AssertionMovementTest, DontMoveThroughBroadcastInstructions) {
   loadCode(3, 3, R"(
   h q[0];
@@ -195,6 +243,10 @@ TEST_F(AssertionMovementTest, DontMoveThroughBroadcastInstructions) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that a broadcast-style assertion is not moved over an instruction
+ * that uses one of the qubits in the broadcast.
+ */
 TEST_F(AssertionMovementTest, DontMoveBroadcastAssertion) {
   loadCode(3, 3, R"(
   h q[0];
@@ -207,6 +259,10 @@ TEST_F(AssertionMovementTest, DontMoveBroadcastAssertion) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that an assertion is not moved over a blocking instruction,
+ * even if the instruction is in a classical control branch.
+ */
 TEST_F(AssertionMovementTest, RelatedClassicControlledGate) {
   loadCode(3, 3, R"(
   x q[0];
@@ -220,6 +276,10 @@ TEST_F(AssertionMovementTest, RelatedClassicControlledGate) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that an assertion is moved over an instruction that is in a
+ * classical control branch, but does not use the assertion's qubits.
+ */
 TEST_F(AssertionMovementTest, UnrelatedClassicControlledGate) {
   loadCode(3, 3, R"(
   x q[0];
@@ -233,6 +293,9 @@ TEST_F(AssertionMovementTest, UnrelatedClassicControlledGate) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that an assertion can be moved even inside custom gate calls.
+ */
 TEST_F(AssertionMovementTest, MoveInsideCustomGate) {
   loadCode(3, 3, R"(
   gate test q {
@@ -246,6 +309,10 @@ TEST_F(AssertionMovementTest, MoveInsideCustomGate) {
   checkMovements(expected);
 }
 
+/**
+ * @test Test that an assertion can be moved inside custom gate calls.
+ * but is not moved out of it.
+ */
 TEST_F(AssertionMovementTest, DontMoveOutsideOfCustomGate) {
   loadCode(3, 3, R"(
   gate test t {

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -103,7 +103,7 @@ TEST_F(AssertionMovementTest, MoveOverBarrier) {
   checkMovements(expected);
 }
 
-TEST_F(AssertionMovementTest, DontMoveMultipleAssertions) {
+/*TEST_F(AssertionMovementTest, DontMoveMultipleAssertions) {
   loadCode(3, 3, R"(
   cx q[0], q[1];
   assert-sup q[0];
@@ -112,7 +112,7 @@ TEST_F(AssertionMovementTest, DontMoveMultipleAssertions) {
 
   const std::set<std::pair<size_t, size_t>> expected;
   checkMovements(expected);
-}
+}*/
 
 TEST_F(AssertionMovementTest, MoveThroughFunctionDefinition) {
   loadCode(3, 3, R"(

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file test_assertion_movement.cpp
+ * @brief Tests the correctness of the assertion movement diagnosis methods.
+ */
+
+#include "backend/dd/DDSimDebug.hpp"
+#include "backend/debug.h"
+#include "backend/diagnostics.h"
+#include "common.h"
+#include "common_fixtures.cpp"
+#include "utils_test.hpp"
+
+#include <array>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @brief Fixture for testing the correctness of assertion movement on custom
+ * code.
+ *
+ * This fixture sets up a DDSimulationState and provides the method
+ * `loadCode` to load custom code into the state.
+ */
+class AssertionMovementTest : public CustomCodeFixture {
+public:
+  void checkMovements(std::set<std::pair<size_t, size_t>> expected) {
+    std::vector<size_t> oldPositions(expected.size() + 1);
+    std::vector<size_t> newPositions(expected.size() + 1);
+    ASSERT_EQ(diagnostics->suggestAssertionMovements(
+                  diagnostics, oldPositions.data(), newPositions.data(),
+                  oldPositions.size()),
+              expected.size());
+
+    for (auto [oldPos, newPos] : expected) {
+      oldPos += 2;
+      newPos += 2;
+      bool found = false;
+      for (size_t i = 0; i < expected.size(); i++) {
+        if (oldPositions[i] == oldPos) {
+          ASSERT_EQ(newPositions[i], newPos)
+              << "Expected " << (newPos - 2) << " but got "
+              << (newPositions[i] - 2) << " for assertion at " << (oldPos - 2);
+          found = true;
+          break;
+        }
+      }
+      ASSERT_TRUE(found) << "No suggestion found for assertion at "
+                         << (oldPos - 2);
+    }
+  }
+};
+
+TEST_F(AssertionMovementTest, MoveOverIndependentInstructions) {
+  loadCode(3, 3, R"(
+  h q[0];
+  cx q[0], q[1];
+  cx q[0], q[2];
+  x q[2];
+  assert-ent q[0], q[1];
+  )");
+
+  checkMovements({{4, 3}});
+}

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -159,7 +159,7 @@ TEST_F(AssertionMovementTest, DontMoveThroughMeasurements) {
   loadCode(3, 3, R"(
   h q[0];
   measure q[1] -> c[1];
-  assert-ent x[0];
+  assert-ent q[0];
   )");
 
   const std::set<std::pair<size_t, size_t>> expected;
@@ -170,7 +170,7 @@ TEST_F(AssertionMovementTest, DontMoveThroughResets) {
   loadCode(3, 3, R"(
   h q[0];
   reset q[1];
-  assert-ent x[0];
+  assert-ent q[0];
   )");
 
   const std::set<std::pair<size_t, size_t>> expected;

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -3,18 +3,12 @@
  * @brief Tests the correctness of the assertion movement diagnosis methods.
  */
 
-#include "backend/dd/DDSimDebug.hpp"
-#include "backend/debug.h"
 #include "backend/diagnostics.h"
-#include "common.h"
-#include "common_fixtures.cpp"
-#include "utils_test.hpp"
+#include "common_fixtures.hpp"
 
-#include <array>
 #include <cstddef>
 #include <gtest/gtest.h>
-#include <sstream>
-#include <string>
+#include <set>
 #include <utility>
 #include <vector>
 

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -27,7 +27,7 @@
  */
 class AssertionMovementTest : public CustomCodeFixture {
 public:
-  void checkMovements(std::set<std::pair<size_t, size_t>> expected) {
+  void checkMovements(const std::set<std::pair<size_t, size_t>>& expected) {
     std::vector<size_t> oldPositions(expected.size() + 1);
     std::vector<size_t> newPositions(expected.size() + 1);
     ASSERT_EQ(diagnostics->suggestAssertionMovements(
@@ -63,5 +63,6 @@ TEST_F(AssertionMovementTest, MoveOverIndependentInstructions) {
   assert-ent q[0], q[1];
   )");
 
-  checkMovements({{4, 3}});
+  const std::set<std::pair<size_t, size_t>> expected = {{4, 3}};
+  checkMovements(expected);
 }

--- a/test/test_assertion_movement.cpp
+++ b/test/test_assertion_movement.cpp
@@ -60,9 +60,157 @@ TEST_F(AssertionMovementTest, MoveOverIndependentInstructions) {
   cx q[0], q[1];
   cx q[0], q[2];
   x q[2];
-  assert-ent q[0], q[1];
+  assert-eq 0.9, q[0], q[1] { 1, 0, 0, 0 }
   )");
 
   const std::set<std::pair<size_t, size_t>> expected = {{4, 3}};
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, MoveEntOverSingleQubit) {
+  loadCode(3, 3, R"(
+  h q[0];
+  cx q[0], q[1];
+  h q[0];
+  x q[0];
+  h q[1];
+  x q[1];
+  assert-ent q[0], q[1];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected = {{6, 2}};
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, MoveSupOverSpecificGates) {
+  loadCode(3, 3, R"(
+  h q[0];
+  cx q[0], q[1];
+  h q[0];
+  y q[0];
+  s q[0];
+  h q[1];
+  x q[1];
+  assert-sup q[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected = {{7, 3}};
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, MoveOverBarrier) {
+  loadCode(3, 3, R"(
+  h q[0];
+  barrier q[0];
+  assert-sup q[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected = {{2, 1}};
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, DontMoveMultipleAssertions) {
+  loadCode(3, 3, R"(
+  cx q[0], q[1];
+  assert-sup q[0];
+  assert-sup q[1];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected;
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, MoveThroughFunctionDefinition) {
+  loadCode(3, 3, R"(
+  h q[0];
+  gate test q { h q; }
+  assert-sup q[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected({{4, 1}});
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, MoveThroughOtherVariableDeclarations) {
+  loadCode(3, 3, R"(
+  h q[0];
+  qreg x[2];
+  creg y[2];
+  assert-sup q[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected({{3, 1}});
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, DontMoveThroughOwnVariableDeclarations) {
+  loadCode(3, 3, R"(
+  h q[0];
+  qreg x[2];
+  x x[0];
+  assert-sup x[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected({{3, 2}});
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, DontMoveThroughMeasurements) {
+  loadCode(3, 3, R"(
+  h q[0];
+  measure q[1] -> c[1];
+  assert-ent x[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected;
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, DontMoveThroughResets) {
+  loadCode(3, 3, R"(
+  h q[0];
+  reset q[1];
+  assert-ent x[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected;
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, DontMoveThroughFunctionCalls) {
+  loadCode(3, 3, R"(
+  h q[0];
+  gate test q { h q; }
+  test q;
+  assert-sup q[0];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected;
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, RelatedClassicControlledGate) {
+  loadCode(3, 3, R"(
+  x q[0];
+  measure q[0] -> c[0];
+  if(c == 0) cx q[1], q[2];
+  x q[1];
+  assert-ent q[1], q[2];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected({{4, 3}});
+  checkMovements(expected);
+}
+
+TEST_F(AssertionMovementTest, UnrelatedClassicControlledGate) {
+  loadCode(3, 3, R"(
+  x q[0];
+  measure q[0] -> c[0];
+  if(c == 0) x q[2];
+  x q[1];
+  assert-ent q[1], q[2];
+  )");
+
+  const std::set<std::pair<size_t, size_t>> expected({{4, 2}});
   checkMovements(expected);
 }

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -11,6 +11,7 @@
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
+#include "common_fixtures.cpp"
 #include "utils_test.hpp"
 
 #include <array>
@@ -25,91 +26,7 @@
  * This fixture sets up a DDSimulationState and provides the method
  * `loadCode` to load custom code into the state.
  */
-class CustomCodeTest : public testing::Test {
-  void SetUp() override {
-    createDDSimulationState(&ddState);
-    state = &ddState.interface;
-  }
-
-protected:
-  /**
-   * @brief The DDSimulationState to use for testing.
-   */
-  DDSimulationState ddState;
-  /**
-   * @brief A reference to the SimulationState interface for easier access.
-   */
-  SimulationState* state = nullptr;
-
-  /**
-   * @brief The full code to load into the state.
-   */
-  std::string fullCode;
-
-  /**
-   * @brief The code provided by the user explicitly.
-   */
-  std::string userCode;
-
-  /*
-   * @brief Load custom code into the state.
-   *
-   * Classical and Quantum registers of the given size are created automatically
-   * with the names `c` and `q`. Therefore, the first instruction in the
-   * provided code will have instruction index 2, as 0 and 1 are reserved for
-   * the registers.\n\n
-   *
-   * At least one classical and quantum bit will always be created, even if the
-   * given number is less than 1.
-   *
-   * @param numQubits The number of qubits to create.
-   * @param numClassics The number of classical bits to create.
-   * @param code The code to load into the state.
-   * @param shouldFail Asserts whether the code should fail to load (i.e., due
-   * to an expected error).
-   * @param preamble The preamble to add to the code before loading declaring
-   * the registers (e.g., library imports).
-   */
-  void loadCode(size_t numQubits, size_t numClassics, const char* code,
-                bool shouldFail = false, const char* preamble = "") {
-    if (numQubits < 1) {
-      numQubits = 1;
-    }
-    if (numClassics < 1) {
-      numClassics = 1;
-    }
-    std::ostringstream ss;
-
-    ss << preamble;
-
-    ss << "qreg q[" << numQubits << "];\n";
-    ss << "creg c[" << numClassics << "];\n";
-
-    ss << code;
-
-    userCode = code;
-    fullCode = ss.str();
-    ASSERT_EQ(state->loadCode(state, fullCode.c_str()),
-              shouldFail ? ERROR : OK);
-  }
-
-  /**
-   * @brief Continue execution until the given instruction is reached.
-   *
-   * Instruction numbers start with 0 for the first instruction defined in the
-   * user code.
-   *
-   * @param instruction The instruction to forward to.
-   */
-  void forwardTo(size_t instruction) {
-    instruction += 2; // Skip the qreg and creg declarations
-    size_t currentInstruction = state->getCurrentInstruction(state);
-    while (currentInstruction < instruction) {
-      state->stepForward(state);
-      currentInstruction = state->getCurrentInstruction(state);
-    }
-  }
-};
+class CustomCodeTest : public CustomCodeFixture {};
 
 /**
  * @test Test the usage of classically controlled operations where the condition

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -267,25 +267,25 @@ TEST_F(CustomCodeTest, BarrierInstruction) {
 }
 
 /**
- * @test Test that an error is returned at runtime if an invalid register index
- * is accessed by an assertion.
+ * @test Test that an error is returned at parse-time if an invalid register
+ * index is accessed by an assertion.
  */
 TEST_F(CustomCodeTest, ErrorAssertionInvalidIndex) {
   loadCode(3, 0,
            "x q[0];"
-           "assert-sup q[3];");
-  ASSERT_EQ(state->runAll(state, nullptr), ERROR);
+           "assert-sup q[3];",
+           true);
 }
 
 /**
- * @test Test that an error is returned at runtime if an invalid register is
+ * @test Test that an error is returned at parse-time if an invalid register is
  * accessed by an assertion.
  */
 TEST_F(CustomCodeTest, ErrorAssertionInvalidQubit) {
   loadCode(3, 0,
            "x q[0];"
-           "assert-sup f[3];");
-  ASSERT_EQ(state->runAll(state, nullptr), ERROR);
+           "assert-sup f[3];",
+           true);
 }
 
 /**

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -7,18 +7,15 @@
  * are not covered by the other tests.
  */
 
-#include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
-#include "common_fixtures.cpp"
+#include "common_fixtures.hpp"
 #include "utils_test.hpp"
 
 #include <array>
 #include <cstddef>
 #include <gtest/gtest.h>
-#include <sstream>
-#include <string>
 
 /**
  * @brief Fixture for testing the correctness of the debugger on custom code.

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -154,6 +154,18 @@ TEST_F(CustomCodeTest, ClassicControlledOperationTrue) {
 }
 
 /**
+ * @test Test the usage of classically controlled operations with multiple
+ * gates.
+ */
+TEST_F(CustomCodeTest, ClassicControlledMultiOperation) {
+  loadCode(2, 1,
+           "x q[0];"
+           "measure q[0] -> c[0];"
+           "if(c==1) { x q[0]; x q[1]; }",
+           true);
+}
+
+/**
  * @test Test the `reset` instruction.
  */
 TEST_F(CustomCodeTest, ResetGate) {

--- a/test/test_data_retrieval.cpp
+++ b/test/test_data_retrieval.cpp
@@ -6,10 +6,9 @@
  * vector.
  */
 
-#include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "common.h"
-#include "common_fixtures.cpp"
+#include "common_fixtures.hpp"
 #include "utils_test.hpp"
 
 #include <array>

--- a/test/test_data_retrieval.cpp
+++ b/test/test_data_retrieval.cpp
@@ -9,6 +9,7 @@
 #include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "common.h"
+#include "common_fixtures.cpp"
 #include "utils_test.hpp"
 
 #include <array>
@@ -24,47 +25,10 @@
  * This fixture creates a DDSimulationState and loads the code from the file
  * `circuits/classical-storage`.
  */
-class DataRetrievalTest : public testing::Test {
+class DataRetrievalTest : public LoadFromFileFixture {
   void SetUp() override {
-    createDDSimulationState(&ddState);
-    state = &ddState.interface;
+    LoadFromFileFixture::SetUp();
     loadFromFile("classical-storage");
-  }
-
-protected:
-  /**
-   * @brief The DDSimulationState to use for testing.
-   */
-  DDSimulationState ddState;
-  /**
-   * @brief A reference to the SimulationState interface for easier access.
-   */
-  SimulationState* state = nullptr;
-
-  /**
-   * @brief Load the code from the file with the given name.
-   *
-   * The given file should be located in the `circuits` directory and use the
-   * `.qasm` extension.
-   * @param testName The name of the file to load (not including the `circuits`
-   * directory path and the extension).
-   */
-  void loadFromFile(const std::string& testName) {
-    const auto code = readFromCircuitsPath(testName);
-    state->loadCode(state, code.c_str());
-  }
-
-  /**
-   * @brief Continue execution until the given instruction is reached.
-   *
-   * @param instruction The instruction to forward to.
-   */
-  void forwardTo(size_t instruction) {
-    size_t currentInstruction = state->getCurrentInstruction(state);
-    while (currentInstruction < instruction) {
-      state->stepForward(state);
-      currentInstruction = state->getCurrentInstruction(state);
-    }
   }
 };
 

--- a/test/test_diagnostics.cpp
+++ b/test/test_diagnostics.cpp
@@ -7,6 +7,7 @@
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
+#include "common_fixtures.cpp"
 #include "utils_test.hpp"
 
 #include <array>
@@ -25,40 +26,7 @@
  * This fixture creates a DDSimulationState and allows to load code from files
  * in the `circuits` directory.
  */
-class DiagnosticsTest : public testing::Test {
-  void SetUp() override {
-    createDDSimulationState(&ddState);
-    state = &ddState.interface;
-    diagnostics = state->getDiagnostics(state);
-  }
-
-protected:
-  /**
-   * @brief The DDSimulationState to use for testing.
-   */
-  DDSimulationState ddState;
-  /**
-   * @brief A reference to the SimulationState interface for easier access.
-   */
-  SimulationState* state = nullptr;
-  /**
-   * @brief A reference to the Diagnostics interface for easier access.
-   */
-  Diagnostics* diagnostics = nullptr;
-
-  /**
-   * @brief Load the code from the file with the given name.
-   *
-   * The given file should be located in the `circuits` directory and use the
-   * `.qasm` extension.
-   * @param testName The name of the file to load (not including the `circuits`
-   * directory path and the extension).
-   */
-  void loadFromFile(const std::string& testName) {
-    const auto code = readFromCircuitsPath(testName);
-    state->loadCode(state, code.c_str());
-  }
-};
+class DiagnosticsTest : public LoadFromFileFixture {};
 
 /**
  * @test Test the correctness of the data dependencies retrieval.

--- a/test/test_diagnostics.cpp
+++ b/test/test_diagnostics.cpp
@@ -3,12 +3,10 @@
  * @brief Test the functionality of the diagnostics module.
  */
 
-#include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
 #include "common.h"
-#include "common_fixtures.cpp"
-#include "utils_test.hpp"
+#include "common_fixtures.hpp"
 
 #include <array>
 #include <cstddef>

--- a/test/test_parsing.cpp
+++ b/test/test_parsing.cpp
@@ -112,7 +112,7 @@ TEST_F(ParsingTest, ErrorInvalidAssertion) {
 TEST_F(ParsingTest, ComplexNumberParsing) {
   // With statevector
   const auto a1 = parseAssertion("assert-eq 0.5, q[0], q[1]",
-                                 "0.5j, 0.5i, 0.5 + 0i, 0 + 0.5j");
+                                 "0.5j, 0.5i, 0.5 + 0i, 0 - 0.5j");
   ASSERT_EQ(a1->getType(), AssertionType::StatevectorEquality);
   ASSERT_EQ(a1->getTargetQubits().size(), 2);
   const auto* sv = dynamic_cast<StatevectorEqualityAssertion*>(a1.get());
@@ -120,7 +120,8 @@ TEST_F(ParsingTest, ComplexNumberParsing) {
                                  sv->getTargetStatevector().numStates);
   for (size_t i = 0; i < 4; i++) {
     ASSERT_EQ(amplitudes[i].real, i != 2 ? 0.0 : 0.5);
-    ASSERT_EQ(amplitudes[i].imaginary, i != 2 ? 0.5 : 0.0);
+    ASSERT_EQ(amplitudes[i].imaginary, i != 2 ? (i != 3 ? 0.5 : -0.5) : 0.0)
+        << i;
   }
 }
 

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -2,11 +2,9 @@
  * @file test_utility.cpp
  * @brief Test the functionality of utility functions provided by the debugger.
  */
-#include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "common.h"
-#include "common_fixtures.cpp"
-#include "utils_test.hpp"
+#include "common_fixtures.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -5,6 +5,7 @@
 #include "backend/dd/DDSimDebug.hpp"
 #include "backend/debug.h"
 #include "common.h"
+#include "common_fixtures.cpp"
 #include "utils_test.hpp"
 
 #include <cstddef>
@@ -19,35 +20,7 @@
  * This fixture creates a DDSimulationState and allows to load code from files
  * in the `circuits` directory.
  */
-class UtilityTest : public testing::Test {
-  void SetUp() override {
-    createDDSimulationState(&ddState);
-    state = &ddState.interface;
-  }
-
-protected:
-  /**
-   * @brief The DDSimulationState to use for testing.
-   */
-  DDSimulationState ddState;
-  /**
-   * @brief A reference to the SimulationState interface for easier access.
-   */
-  SimulationState* state = nullptr;
-
-  /**
-   * @brief Load the code from the file with the given name.
-   *
-   * The given file should be located in the `circuits` directory and use the
-   * `.qasm` extension.
-   * @param testName The name of the file to load (not including the `circuits`
-   * directory path and the extension).
-   */
-  void loadFromFile(const std::string& testName) {
-    const auto code = readFromCircuitsPath(testName);
-    state->loadCode(state, code.c_str());
-  }
-};
+class UtilityTest : public LoadFromFileFixture {};
 
 /**
  * @test Test the retrieval of the number of instructions in the loaded code.

--- a/test/utils/common_fixtures.hpp
+++ b/test/utils/common_fixtures.hpp
@@ -7,10 +7,13 @@
 #include "backend/dd/DDSimDiagnostics.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
+#include "common.h"
 #include "utils_test.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
+#include <sstream>
+#include <string>
 
 /**
  * @brief Fixture that loads custom code.


### PR DESCRIPTION
## Description

This pull request adds all assertion refinement features discussed in the new assertion refinement paper to the
MQT Debugger.

This includes:
- Moving Assertions:
  - Defines a set of commutation rules that allow assertions to be moved
- Creating Assertions:
  - Uses interaction graph methods to add new entanglement assertions
  - Splits larger entanglement and equality assertions into smaller ones

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
